### PR TITLE
Fix some broken links

### DIFF
--- a/local/docs/sedfaq.html
+++ b/local/docs/sedfaq.html
@@ -179,8 +179,6 @@ CONTENTS:
 
       <a href="http://sed.sourceforge.net/sedfaq.html">http://sed.sourceforge.net/sedfaq.html</a>
       <a href="http://sed.sourceforge.net/sedfaq.txt">http://sed.sourceforge.net/sedfaq.txt</a>
-      <a href="http://www.dbnet.ece.ntua.gr/~george/sed/sedfaq.html">http://www.dbnet.ece.ntua.gr/~george/sed/sedfaq.html</a>
-      <a href="http://www.dbnet.ece.ntua.gr/~george/sed/sedfaq.txt">http://www.dbnet.ece.ntua.gr/~george/sed/sedfaq.txt</a>
       <a href="http://www.ptug.org/sed/sedfaq.html">http://www.ptug.org/sed/sedfaq.html</a>
       <a href="http://www.faqs.org/faqs/editor-faq/sed">http://www.faqs.org/faqs/editor-faq/sed</a>
       <a href="ftp://rtfm.mit.edu/pub/faqs/editor-faq/sed">ftp://rtfm.mit.edu/pub/faqs/editor-faq/sed</a>

--- a/local/docs/sedfaq.html
+++ b/local/docs/sedfaq.html
@@ -25,7 +25,7 @@ Archive-name: editor-faq/sed
 Posting-Frequency: bimonthly
 Last-modified: 2000/04/28
 Version: 014
-URL: <a href="http://www.cornerstonemag.com/sed/sedfaq.html">http://www.cornerstonemag.com/sed/sedfaq.html</a>
+URL: <a href="http://sed.sourceforge.net/sedfaq.html">http://sed.sourceforge.net/sedfaq.html</a>
 Maintainer: Eric Pement &lt;<a href="mailto:epement@jpusa.chi.il.us">epement@jpusa.chi.il.us</a>&gt;
 
 
@@ -177,8 +177,8 @@ CONTENTS:
 
    The newest version of the sed FAQ is usually here:
 
-      <a href="http://www.cornerstonemag.com/sed/sedfaq.html">http://www.cornerstonemag.com/sed/sedfaq.html</a>
-      <a href="http://www.cornerstonemag.com/sed/sedfaq.txt">http://www.cornerstonemag.com/sed/sedfaq.txt</a>
+      <a href="http://sed.sourceforge.net/sedfaq.html">http://sed.sourceforge.net/sedfaq.html</a>
+      <a href="http://sed.sourceforge.net/sedfaq.txt">http://sed.sourceforge.net/sedfaq.txt</a>
       <a href="http://www.dbnet.ece.ntua.gr/~george/sed/sedfaq.html">http://www.dbnet.ece.ntua.gr/~george/sed/sedfaq.html</a>
       <a href="http://www.dbnet.ece.ntua.gr/~george/sed/sedfaq.txt">http://www.dbnet.ece.ntua.gr/~george/sed/sedfaq.txt</a>
       <a href="http://www.ptug.org/sed/sedfaq.html">http://www.ptug.org/sed/sedfaq.html</a>


### PR DESCRIPTION
This doesn't look like the copy of the version that is actually being served by http://sed.sourceforge.net/sedfaq.html, so I'm not sure of the relationship/ownership, but I figured I'd go ahead and fix these links.

This file still has some broken links to www.cornerstonemag.com, but I wasn't sure if all of those files were hosted at the sed.sourceforge.net site.
