### PR TITLE
Add grabbag HTML pages (edit needed)

### DIFF
--- a/grabbag/index.html
+++ b/grabbag/index.html
@@ -4,7 +4,7 @@
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>Seder's grab bag</title>
-    <style type="text/css">@import url(/web/20211028141011cs_/http://sed.sourceforge.net/grabbag/seders.css);</style>
+    <style type="text/css">@import url(/grabbag/seders.css);</style>
   </head>
 
   <body>

--- a/grabbag/index.html
+++ b/grabbag/index.html
@@ -1,15 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html lang="en">
-  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
-<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
-<script type="text/javascript">
-  __wm.init("https://web.archive.org/web");
-  __wm.wombat("http://sed.sourceforge.net/grabbag/","20211028141011","https://web.archive.org/","web","/_static/",
-	      "1635430211");
-</script>
-<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
-<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
-<!-- End Wayback Rewrite JS Include -->
+  <head>
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>Seder's grab bag</title>
@@ -52,24 +43,3 @@
     </div>
   </body>
 </html>
-
-<!--
-     FILE ARCHIVED ON 14:10:11 Oct 28, 2021 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 22:36:44 Apr 26, 2023.
-     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
-
-     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
-     SECTION 108(a)(3)).
--->
-<!--
-playback timings (ms):
-  captures_list: 229.645
-  exclusion.robots: 0.148
-  exclusion.robots.policy: 0.137
-  RedisCDXSource: 15.523
-  esindex: 0.007
-  LoadShardBlock: 188.393 (3)
-  PetaboxLoader3.datanode: 79.225 (4)
-  PetaboxLoader3.resolve: 231.457 (2)
-  load_resource: 1400.725
--->

--- a/grabbag/index.html
+++ b/grabbag/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("http://sed.sourceforge.net/grabbag/","20211028141011","https://web.archive.org/","web","/_static/",
+	      "1635430211");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
+    <title>Seder's grab bag</title>
+    <style type="text/css">@import url(/web/20211028141011cs_/http://sed.sourceforge.net/grabbag/seders.css);</style>
+  </head>
+
+  <body>
+    <div class="titolo">
+      <div class="sezioni">
+      <h1><a href="index.htm"><span>seder's</span> grab bag</a></h1>
+      <ul>
+        <li><a href="scripts/">scripts</a></li>
+	<li><a href="tutorials/">tutorials</a></li>
+	<li><a href="seders/">seders</a></li>
+	<li><a href="ssed/">ssed</a></li>
+	<li><a href="links/">links</a></li>
+      </ul>
+      </div>
+    </div>
+
+    <div class="menu"></div>
+    <div class="testo">
+
+    <p>The <cite>seder's grab-bag</cite> is a resource for sed users. I collect scripts,
+    executables, HOWTO's, tips and all kinds of stuff, and post them for all and sundry to use.</p>
+
+    <p>The <cite>seder's grab-bag</cite> is also home to <a href="seders/" target="_top">seders</a>, an open, informal mailing list which discusses sed and friends.</p>
+
+    <p>To be really useful, the Grab-bag needs regular input. If have any scripts, texts, tips,
+    reviews, executables or source you would like to publish, I would like to hear from you. Please
+    email all contributions (or URLs) and feedback to <a href="https://web.archive.org/web/20211028141011/mailto:bonzini@gnu.org">me</a>. Your
+    work will be credited, and a link to your page included if you wish. All scripts on these pages
+    are in the public domain.</p>
+
+    <p><span class="update">Updated 11 Mar 2002</span></p>
+
+    <p><a href="https://web.archive.org/web/20211028141011/http://www.w3.org/Style/CSS/Buttons"><img alt="Made with CSS!" border="0" src="https://web.archive.org/web/20211028141011im_/http://www.w3.org/Style/CSS/Buttons/mwcts"></a>
+     <a href="https://web.archive.org/web/20211028141011/http://jigsaw.w3.org/css-validator"><img border="0" src="https://web.archive.org/web/20211028141011im_/http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a> 
+     <a href="https://web.archive.org/web/20211028141011/http://validator.w3.org/check/referer"><img border="0" src="https://web.archive.org/web/20211028141011im_/http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!" height="31" width="88"></a>
+    </div>
+  </body>
+</html>
+
+<!--
+     FILE ARCHIVED ON 14:10:11 Oct 28, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 22:36:44 Apr 26, 2023.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 229.645
+  exclusion.robots: 0.148
+  exclusion.robots.policy: 0.137
+  RedisCDXSource: 15.523
+  esindex: 0.007
+  LoadShardBlock: 188.393 (3)
+  PetaboxLoader3.datanode: 79.225 (4)
+  PetaboxLoader3.resolve: 231.457 (2)
+  load_resource: 1400.725
+-->

--- a/grabbag/index.html
+++ b/grabbag/index.html
@@ -37,9 +37,9 @@
 
     <p><span class="update">Updated 11 Mar 2002</span></p>
 
-    <p><a href="http://www.w3.org/Style/CSS/Buttons"><img alt="Made with CSS!" border="0" src="https://web.archive.org/web/20211028141011im_/http://www.w3.org/Style/CSS/Buttons/mwcts"></a>
-     <a href="http://jigsaw.w3.org/css-validator"><img border="0" src="https://web.archive.org/web/20211028141011im_/http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a> 
-     <a href="http://validator.w3.org/check/referer"><img border="0" src="https://web.archive.org/web/20211028141011im_/http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!" height="31" width="88"></a>
+    <p><a href="http://www.w3.org/Style/CSS/Buttons"><img alt="Made with CSS!" border="0" src="http://www.w3.org/Style/CSS/Buttons/mwcts"></a>
+     <a href="http://jigsaw.w3.org/css-validator"><img border="0" src="http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a> 
+     <a href="http://validator.w3.org/check/referer"><img border="0" src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!" height="31" width="88"></a>
     </div>
   </body>
 </html>

--- a/grabbag/index.html
+++ b/grabbag/index.html
@@ -31,15 +31,15 @@
 
     <p>To be really useful, the Grab-bag needs regular input. If have any scripts, texts, tips,
     reviews, executables or source you would like to publish, I would like to hear from you. Please
-    email all contributions (or URLs) and feedback to <a href="https://web.archive.org/web/20211028141011/mailto:bonzini@gnu.org">me</a>. Your
+    email all contributions (or URLs) and feedback to <a href="mailto:bonzini@gnu.org">me</a>. Your
     work will be credited, and a link to your page included if you wish. All scripts on these pages
     are in the public domain.</p>
 
     <p><span class="update">Updated 11 Mar 2002</span></p>
 
-    <p><a href="https://web.archive.org/web/20211028141011/http://www.w3.org/Style/CSS/Buttons"><img alt="Made with CSS!" border="0" src="https://web.archive.org/web/20211028141011im_/http://www.w3.org/Style/CSS/Buttons/mwcts"></a>
-     <a href="https://web.archive.org/web/20211028141011/http://jigsaw.w3.org/css-validator"><img border="0" src="https://web.archive.org/web/20211028141011im_/http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a> 
-     <a href="https://web.archive.org/web/20211028141011/http://validator.w3.org/check/referer"><img border="0" src="https://web.archive.org/web/20211028141011im_/http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!" height="31" width="88"></a>
+    <p><a href="http://www.w3.org/Style/CSS/Buttons"><img alt="Made with CSS!" border="0" src="https://web.archive.org/web/20211028141011im_/http://www.w3.org/Style/CSS/Buttons/mwcts"></a>
+     <a href="http://jigsaw.w3.org/css-validator"><img border="0" src="https://web.archive.org/web/20211028141011im_/http://jigsaw.w3.org/css-validator/images/vcss" alt="Valid CSS!"></a> 
+     <a href="http://validator.w3.org/check/referer"><img border="0" src="https://web.archive.org/web/20211028141011im_/http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01!" height="31" width="88"></a>
     </div>
   </body>
 </html>

--- a/grabbag/links/index.html
+++ b/grabbag/links/index.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("http://sed.sourceforge.net/grabbag/links/","20210916192447","https://web.archive.org/","web","/_static/",
+	      "1631820287");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
+    <title>Seder's grab bag - sed resources</title>
+    <style type="text/css">@import url(/web/20210916192447cs_/http://sed.sourceforge.net/grabbag/seders.css);</style>
+  </head>
+
+  <body>
+    <div class="titolo">
+      <div class="sezioni">
+      <h1><a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/"><span>seder's</span> grab bag</a></h1>
+      <ul>
+        <li><a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/scripts/">scripts</a></li>
+        <li><a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/tutorials/">tutorials</a></li>
+        <li><a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/seders/">seders</a></li>
+        <li><a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/ssed/">ssed</a></li>
+        <li><a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/links/">links</a></li>
+      </ul>
+      </div>
+    </div>
+
+    <ul class="menu">
+      <li><a href="#www">WWW</a></li>
+      <li><a href="#usenet">Usenet</a></li>
+      <li><a href="#mail">Mailing lists</a></li>
+      <li><a href="#books">Books</a></li>
+    </ul>
+
+    <div class="testo">
+    <h2>Resources</h2>
+
+    <p>This is a collection of links I've found to sed resources available on or via the Net. If
+    you have anything to add, or you have any broken links to report, please <a href="https://web.archive.org/web/20210916192447/mailto:bonzini@gnu.org">email me</a>.</p>
+    <hr width="70%">
+
+    <h3 id="www">WWW</h3>
+
+    <dl>
+      <dt><a href="https://web.archive.org/web/20210916192447/http://www.guckes.net/sven/">Sven Guckes home page</a></dt>
+
+      <dd>
+        <div class="last">
+          A page with lots of sed links. Many more useful links on perl, Lynx, vim, MUTT, SLRN and
+          other utilities can be found at Sven's <a href="https://web.archive.org/web/20210916192447/http://www.math.fu-berlin.de/~guckes/sed/">home page</a>.
+        </div>
+      </dd>
+
+      <dt><a href="https://web.archive.org/web/20210916192447/http://www.student.northpark.edu/pemente/sed/index.htm">Eric Pement's sed
+      page</a></dt>
+
+      <dd>
+        <div class="last">
+          This is the sed page by the author of the sed FAQ.
+        </div>
+      </dd>
+
+      <dt><a href="https://web.archive.org/web/20210916192447/http://www.rtfiber.com.tw/~changyj/sed">Yao-Jen Chang's sed page</a></dt>
+
+      <dd>
+        <div class="last">
+          Yao-Jen also has an interesting page with some interesting and tricky sed scripts he
+          wrote.
+        </div>
+      </dd>
+    </dl>
+
+    <h3 id="usenet">Usenet</h3>
+
+    <dl>
+      <dt><a href="https://web.archive.org/web/20210916192447/news:alt.comp.editors.batch">alt.comp.editors.batch</a></dt>
+
+      <dd>
+        <div class="last">
+          A recently formed group for discussing batch editing languages, tools, techniques and
+          suchlike.<br>
+        </div>
+      </dd>
+
+      <dt><a href="https://web.archive.org/web/20210916192447/news:comp.editors">comp.editors</a></dt>
+
+      <dd>
+        <div class="last">
+          Start here.<br>
+           Also available are the <a href="https://web.archive.org/web/20210916192447/ftp://sunsite.doc.ic.ac.uk/pub/usenet/usenet-by-hierarchy/comp/editors/">comp.editors
+          FAQs</a> (currently for vi and VIM only).<br>
+        </div>
+      </dd>
+
+      <dt><a href="https://web.archive.org/web/20210916192447/news:comp.lang.misc">comp.lang.misc</a></dt>
+
+      <dd>
+        <div class="last">
+          Discusses compilers, tools &amp; languages.<br>
+           comp.lang.misc also has a <a href="https://web.archive.org/web/20210916192447/http://www.idiom.com/free-compilers/">catalogue</a>.
+          Currently, the only sed it lists is GNU sed, but there is a wealth of alternative
+          utilities for all platforms. From the intro: 
+
+          <blockquote>
+            This list catalogues freely available software for language tools, which includes the
+            libraries, assemblers, etc. -- things whose user interface is a language. Natural
+            language processing tools may also be included.
+          </blockquote>
+          An up-to-date list is also available via ftp (~345k, multi-part) from <a href="https://web.archive.org/web/20210916192447/ftp://ftp.idiom.com/pub/compilers-list/free-compilers">ftp.idiom.com</a> and <a href="https://web.archive.org/web/20210916192447/ftp://sunsite.doc.ic.ac.uk/pub/usenet/usenet-by-hierarchy/comp/lang/misc/">sunsite.doc.ic.ac.uk</a>.<br>
+
+        </div>
+      </dd>
+
+      <dt><a href="https://web.archive.org/web/20210916192447/news:comp.unix.shell">comp.unix.shell</a></dt>
+
+      <dd>
+        <div class="last">
+          Problems incorporating sed in a shell script?
+        </div>
+      </dd>
+    </dl>
+
+    <h3 id="mail">Mailing lists</h3>
+
+    <dl>
+      <dt><a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/seders/">sed-users</a></dt>
+
+      <dd>
+        <div class="last">
+          Join us!
+        </div>
+      </dd>
+    </dl>
+
+    <h3 id="books">Books</h3>
+
+    <dl>
+      <dt><a href="https://web.archive.org/web/20210916192447/http://www.ora.com/catalog/sed2/">sed &amp; awk</a> (2nd edition)<br>
+       <i>See also</i>: <a href="https://web.archive.org/web/20210916192447/http://www.ora.com/catalog/sed/">(1st edition)</a></dt>
+
+      <dd>
+        <div class="last">
+          By Dale Dougherty. Heavily reviewed, and considered by many to be the sed bible. The
+          second edition deals with GNU sed. One of the unrivalled series of Nutshell Handbooks
+          from <a href="https://web.archive.org/web/20210916192447/http://www.ora.com/">O'Reilly &amp; Associates</a>. Unfortunately, this
+          books deals far more with awk than sed, but it is still a valuable resource, and
+          indispensable for anyone who uses these two classic utilities seriously.
+        </div>
+      </dd>
+    </dl>
+    Also check out the <a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/tutorials/">tutorials page</a> for useful
+    introductions and discussions on sed. 
+
+    <p><span class="update">Updated 11 Feb 2005</span></p>
+    </div>
+  </body>
+</html>
+
+<!--
+     FILE ARCHIVED ON 19:24:47 Sep 16, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 22:37:02 Apr 26, 2023.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 82.781
+  exclusion.robots: 0.145
+  exclusion.robots.policy: 0.13
+  RedisCDXSource: 0.696
+  esindex: 0.01
+  LoadShardBlock: 52.973 (3)
+  PetaboxLoader3.datanode: 703.882 (4)
+  PetaboxLoader3.resolve: 94.629 (2)
+  load_resource: 749.258
+-->

--- a/grabbag/links/index.html
+++ b/grabbag/links/index.html
@@ -32,22 +32,22 @@
     <h2>Resources</h2>
 
     <p>This is a collection of links I've found to sed resources available on or via the Net. If
-    you have anything to add, or you have any broken links to report, please <a href="https://web.archive.org/web/20210916192447/mailto:bonzini@gnu.org">email me</a>.</p>
+    you have anything to add, or you have any broken links to report, please <a href="mailto:bonzini@gnu.org">email me</a>.</p>
     <hr width="70%">
 
     <h3 id="www">WWW</h3>
 
     <dl>
-      <dt><a href="https://web.archive.org/web/20210916192447/http://www.guckes.net/sven/">Sven Guckes home page</a></dt>
+      <dt><a href="http://www.guckes.net/sven/">Sven Guckes home page</a></dt>
 
       <dd>
         <div class="last">
           A page with lots of sed links. Many more useful links on perl, Lynx, vim, MUTT, SLRN and
-          other utilities can be found at Sven's <a href="https://web.archive.org/web/20210916192447/http://www.math.fu-berlin.de/~guckes/sed/">home page</a>.
+          other utilities can be found at Sven's <a href="http://www.math.fu-berlin.de/~guckes/sed/">home page</a>.
         </div>
       </dd>
 
-      <dt><a href="https://web.archive.org/web/20210916192447/http://www.student.northpark.edu/pemente/sed/index.htm">Eric Pement's sed
+      <dt><a href="http://www.student.northpark.edu/pemente/sed/index.htm">Eric Pement's sed
       page</a></dt>
 
       <dd>
@@ -56,7 +56,7 @@
         </div>
       </dd>
 
-      <dt><a href="https://web.archive.org/web/20210916192447/http://www.rtfiber.com.tw/~changyj/sed">Yao-Jen Chang's sed page</a></dt>
+      <dt><a href="http://www.rtfiber.com.tw/~changyj/sed">Yao-Jen Chang's sed page</a></dt>
 
       <dd>
         <div class="last">
@@ -69,7 +69,7 @@
     <h3 id="usenet">Usenet</h3>
 
     <dl>
-      <dt><a href="https://web.archive.org/web/20210916192447/news:alt.comp.editors.batch">alt.comp.editors.batch</a></dt>
+      <dt><a href="news:alt.comp.editors.batch">alt.comp.editors.batch</a></dt>
 
       <dd>
         <div class="last">
@@ -78,22 +78,22 @@
         </div>
       </dd>
 
-      <dt><a href="https://web.archive.org/web/20210916192447/news:comp.editors">comp.editors</a></dt>
+      <dt><a href="news:comp.editors">comp.editors</a></dt>
 
       <dd>
         <div class="last">
           Start here.<br>
-           Also available are the <a href="https://web.archive.org/web/20210916192447/ftp://sunsite.doc.ic.ac.uk/pub/usenet/usenet-by-hierarchy/comp/editors/">comp.editors
+           Also available are the <a href="ftp://sunsite.doc.ic.ac.uk/pub/usenet/usenet-by-hierarchy/comp/editors/">comp.editors
           FAQs</a> (currently for vi and VIM only).<br>
         </div>
       </dd>
 
-      <dt><a href="https://web.archive.org/web/20210916192447/news:comp.lang.misc">comp.lang.misc</a></dt>
+      <dt><a href="news:comp.lang.misc">comp.lang.misc</a></dt>
 
       <dd>
         <div class="last">
           Discusses compilers, tools &amp; languages.<br>
-           comp.lang.misc also has a <a href="https://web.archive.org/web/20210916192447/http://www.idiom.com/free-compilers/">catalogue</a>.
+           comp.lang.misc also has a <a href="http://www.idiom.com/free-compilers/">catalogue</a>.
           Currently, the only sed it lists is GNU sed, but there is a wealth of alternative
           utilities for all platforms. From the intro: 
 
@@ -102,12 +102,12 @@
             libraries, assemblers, etc. -- things whose user interface is a language. Natural
             language processing tools may also be included.
           </blockquote>
-          An up-to-date list is also available via ftp (~345k, multi-part) from <a href="https://web.archive.org/web/20210916192447/ftp://ftp.idiom.com/pub/compilers-list/free-compilers">ftp.idiom.com</a> and <a href="https://web.archive.org/web/20210916192447/ftp://sunsite.doc.ic.ac.uk/pub/usenet/usenet-by-hierarchy/comp/lang/misc/">sunsite.doc.ic.ac.uk</a>.<br>
+          An up-to-date list is also available via ftp (~345k, multi-part) from <a href="ftp://ftp.idiom.com/pub/compilers-list/free-compilers">ftp.idiom.com</a> and <a href="ftp://sunsite.doc.ic.ac.uk/pub/usenet/usenet-by-hierarchy/comp/lang/misc/">sunsite.doc.ic.ac.uk</a>.<br>
 
         </div>
       </dd>
 
-      <dt><a href="https://web.archive.org/web/20210916192447/news:comp.unix.shell">comp.unix.shell</a></dt>
+      <dt><a href="news:comp.unix.shell">comp.unix.shell</a></dt>
 
       <dd>
         <div class="last">
@@ -131,14 +131,14 @@
     <h3 id="books">Books</h3>
 
     <dl>
-      <dt><a href="https://web.archive.org/web/20210916192447/http://www.ora.com/catalog/sed2/">sed &amp; awk</a> (2nd edition)<br>
-       <i>See also</i>: <a href="https://web.archive.org/web/20210916192447/http://www.ora.com/catalog/sed/">(1st edition)</a></dt>
+      <dt><a href="http://www.ora.com/catalog/sed2/">sed &amp; awk</a> (2nd edition)<br>
+       <i>See also</i>: <a href="http://www.ora.com/catalog/sed/">(1st edition)</a></dt>
 
       <dd>
         <div class="last">
           By Dale Dougherty. Heavily reviewed, and considered by many to be the sed bible. The
           second edition deals with GNU sed. One of the unrivalled series of Nutshell Handbooks
-          from <a href="https://web.archive.org/web/20210916192447/http://www.ora.com/">O'Reilly &amp; Associates</a>. Unfortunately, this
+          from <a href="http://www.ora.com/">O'Reilly &amp; Associates</a>. Unfortunately, this
           books deals far more with awk than sed, but it is still a valuable resource, and
           indispensable for anyone who uses these two classic utilities seriously.
         </div>

--- a/grabbag/links/index.html
+++ b/grabbag/links/index.html
@@ -4,19 +4,19 @@
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>Seder's grab bag - sed resources</title>
-    <style type="text/css">@import url(/web/20210916192447cs_/http://sed.sourceforge.net/grabbag/seders.css);</style>
+    <style type="text/css">@import url(/grabbag/seders.css);</style>
   </head>
 
   <body>
     <div class="titolo">
       <div class="sezioni">
-      <h1><a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/"><span>seder's</span> grab bag</a></h1>
+      <h1><a href="/grabbag/"><span>seder's</span> grab bag</a></h1>
       <ul>
-        <li><a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/scripts/">scripts</a></li>
-        <li><a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/tutorials/">tutorials</a></li>
-        <li><a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/seders/">seders</a></li>
-        <li><a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/ssed/">ssed</a></li>
-        <li><a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/links/">links</a></li>
+        <li><a href="/grabbag/scripts/">scripts</a></li>
+        <li><a href="/grabbag/tutorials/">tutorials</a></li>
+        <li><a href="/grabbag/seders/">seders</a></li>
+        <li><a href="/grabbag/ssed/">ssed</a></li>
+        <li><a href="/grabbag/links/">links</a></li>
       </ul>
       </div>
     </div>
@@ -119,7 +119,7 @@
     <h3 id="mail">Mailing lists</h3>
 
     <dl>
-      <dt><a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/seders/">sed-users</a></dt>
+      <dt><a href="/grabbag/seders/">sed-users</a></dt>
 
       <dd>
         <div class="last">
@@ -144,7 +144,7 @@
         </div>
       </dd>
     </dl>
-    Also check out the <a href="/web/20210916192447/http://sed.sourceforge.net/grabbag/tutorials/">tutorials page</a> for useful
+    Also check out the <a href="/grabbag/tutorials/">tutorials page</a> for useful
     introductions and discussions on sed. 
 
     <p><span class="update">Updated 11 Feb 2005</span></p>

--- a/grabbag/links/index.html
+++ b/grabbag/links/index.html
@@ -1,15 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html lang="en">
-  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
-<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
-<script type="text/javascript">
-  __wm.init("https://web.archive.org/web");
-  __wm.wombat("http://sed.sourceforge.net/grabbag/links/","20210916192447","https://web.archive.org/","web","/_static/",
-	      "1631820287");
-</script>
-<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
-<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
-<!-- End Wayback Rewrite JS Include -->
+  <head>
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>Seder's grab bag - sed resources</title>
@@ -160,24 +151,3 @@
     </div>
   </body>
 </html>
-
-<!--
-     FILE ARCHIVED ON 19:24:47 Sep 16, 2021 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 22:37:02 Apr 26, 2023.
-     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
-
-     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
-     SECTION 108(a)(3)).
--->
-<!--
-playback timings (ms):
-  captures_list: 82.781
-  exclusion.robots: 0.145
-  exclusion.robots.policy: 0.13
-  RedisCDXSource: 0.696
-  esindex: 0.01
-  LoadShardBlock: 52.973 (3)
-  PetaboxLoader3.datanode: 703.882 (4)
-  PetaboxLoader3.resolve: 94.629 (2)
-  load_resource: 749.258
--->

--- a/grabbag/scripts/dc_overview.htm
+++ b/grabbag/scripts/dc_overview.htm
@@ -1,0 +1,285 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("http://sed.sourceforge.net/grabbag/scripts/dc_overview.htm","20211026153130","https://web.archive.org/","web","/_static/",
+	      "1635262290");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
+    <title>Overview of How the dc.sed Script Works</title>
+  </head>
+
+  <body>
+    <h1 align="center">Overview of How the <code>dc.sed</code> Script Works</h1>
+
+    <h2 align="center">Greg Ubben, 5 March 2001</h2>
+
+    <blockquote>
+      <hr align="left" width="10%" noshadow="">
+      <i>[<code><a href="dc.sed">dc.sed</a></code> is an arbitrary precision and radix RPN
+      calculator written in the <code>sed</code> stream-editor "language". It was posted to the
+      "seders" mailing list in February 1997. I assume knowledge of the Unix <code><a href="dc.1.txt">dc</a></code> command and regular expressions here.]</i> 
+      <hr align="left" width="10%" noshadow="">
+    </blockquote>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; As you probably know, <code>sed</code> only has one long
+    text buffer (also called the pattern space), plus one alternate buffer (the hold space). This
+    buffer is usually limited to several thousand characters on traditional Unix versions of
+    <code>sed</code>. Between operations, the numbers are stored in this buffer in normal decimal
+    format. The buffer is partitioned into various parts using <code>|</code> and <code>~</code> as
+    delimiters so that any amount of numbers can be kept on the stack and also in various
+    <code>dc</code> register stacks. The actually format of the buffer is:</p>
+<pre>
+    &lt;stack&gt;|P|K0|I10|O10|ra&lt;stack&gt;|rx&lt;stack&gt;|rZ&lt;stack&gt;|?&lt;input-stack&gt;
+</pre>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; where <i>&lt;stack&gt;</i> is a sequence of 0 or more
+    numbers or strings, each followed by a tilde (<code>~</code>). (The stack items cannot contain
+    <code>|</code> or <code>~</code>.) The first stack is the working stack, <code>|P</code> is any
+    partial output line (which we need to buffer since <code>sed</code> can't print a partial
+    line), <code>|K</code> is the current scale, <code>|I</code> the current input base,
+    <code>|O</code> the current output base, <code>|rx</code> is register <i>x</i>, and
+    <code>|?</code> is the input stack. For example, if pushing <i>365</i> and <i>-3.14</i> on the
+    stack and storing <i>66411</i> in register <i>b</i>, you would have these before and after
+    buffer contents:</p>
+<pre>
+    |P|K0|I10|O10|? 365 _3.14 66411sb
+    -3.14~365~|P|K0|I10|O10|rb66411~|?
+</pre>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; To summarize how the calculations are done, I guess you
+    could say the core routines temporarily convert the working digits to "analog" format (e.g.,
+    <i>6</i>=<code>aaaaaa</code>) where regular expressions can work with them easier. And the
+    other routines are implemented in high-level <code>dc</code> code that is "boot-strapped" from
+    <code>sed</code>. <code>sed</code>'s hold space is used to store the rest of the buffer during
+    low-level operations so only the part you're currently working with is present.</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; There are two core routines: addition/subtraction and
+    multiplication. Almost everything else is built on top of these. You could say the add/sub uses
+    a "number line" to do the math. After much frustration (one of the reasons I stopped on it for
+    over a year (the other reason being once I saw the whole thing could be done, I lost interest
+    in it a bit)), I was able to come up with an algorithm that had enough similarity in the
+    addition and subtraction that I could use the same code for both, but just starting with a
+    different "lookup table". I needed this because I wanted to stay within the 199-command limit
+    that traditional Unix <code>sed</code> implementations have. (I kept track of how close I was
+    to this command limit all during development, and ended up with none to spare, though I've
+    since identified several places I could crunch out room for a few more if I had to.)</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; As I recall, the add/sub first starts out by normalizing
+    the two numbers a bit, reducing the number of cases. E.g., <nobr><i>-5 - -8</i></nobr> and
+    <nobr><i>8 + -5</i></nobr> are both the same as <nobr><i>8 - 5</i></nobr>. And it handles
+    <code>dc</code>'s comparison (&lt;,=,&gt;) functions at this point, since a comparison needs to
+    be done here anyway to determine which order to subtract the numbers in (since my combined
+    add/sub algorithm requires the smaller absolute value to be subtracted from the larger one). To
+    compare, it starts at the decimal point (or right end if no decimal) of each number and works
+    to the left until it reaches the left end of one of the numbers. If there's any left over (one
+    number is longer), that's the larger one.</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; Otherwise it uses an interesting technique (originally
+    used in my <code>sort.sed</code>) to find the first digit that differs in the two numbers and
+    compare which is greater. The technique is basically to append a "lookup table" to the buffer.
+    For example, if <code>"38;0123456789"</code> can be matched by the (extended) regular
+    expression <code>/^(.)(.).*\1.*\2/</code>, that means the first two digits (<i>3</i> and
+    <i>8</i>) are in ascending order, as it found them in the lookup table in that order. Except
+    this regular expression is combined with the part that skips the leading digits the two numbers
+    have in common (which comes out pretty slick using the powerful back- referencing and
+    backtracking features of regexes).</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; This same lookup-table technique is used in quite a few
+    places in the script. It really cuts down on the number of <code>sed</code> commands since you
+    just need two <code>s///</code> commands -- one to append the lookup table, and a complex one
+    to do the lookup and replace (removing the table at the same time). For example, if the
+    <code>sed</code> buffer contained a single digit (say 7) and I wanted to convert it to analog,
+    I'd first append a lookup table to it like this:
+    <code><nobr>s/$/9876543210aaaaaaaaa/</nobr></code> Then the regular expression just needs to
+    find the digit in the lookup table (using a back-reference), skip 9 characters further, and the
+    rest of the a's after that will be the result. Here is the substitute command to do this (in
+    extended regular expression syntax to avoid all the ugly backslashes):
+    <code><nobr>s/(.).*\1.{9}//</nobr></code> This leaves just <code>aaaaaaa</code> in the buffer
+    if the first digit was a 7. The conversion back works pretty much the same way:</p>
+<pre>
+                # start with:    aaaaaaa
+    s/$/9876543210/     # append table:  aaaaaaa9876543210
+    s/.{9}(.).*/\1/     # final result:  7
+</pre>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; Anyway, getting back to the add/sub, it then starts back
+    at the decimal point and iterates to the right through the factions of the two numbers until it
+    finds the number with the shorter fraction. This is because you have to start
+    adding/subtracting on the right side at the same decimal position. (An explicit iteration loop
+    is needed because a regular expression can't say "take the length of this string of characters
+    here and find the same number of characters at a point later on in the string" (unless they are
+    all the same character).) The result gets initialized with any extra fraction to the right. For
+    example, in <i>3.14159 + 36.75</i>, the result gets initialized with the <i>159</i>. Finally,
+    the main add/sub loop starts working, adding or subtracting one digit at a time leftwards
+    (depending on which lookup table was appended earlier).</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; It uses what you could call a "dynamic double" lookup
+    trick to add/sub the two digits. Basically, if you're adding the digits <i>5</i> and <i>8</i>,
+    it looks both up (at the same time) in the double lookup table
+    <code>"9876543210;9876543210"</code> and gets the remaining digits for each following that
+    position. So you'd get <code>43210</code> and <code>76543210</code> for <i>5</i> and <i>8</i>.
+    Then these are concatenated with another fixed table to get
+    <code>43210765432109876543210</code>. If you then start at the left side of that and count 10
+    characters in, you get the one's digit sum (<i>3</i>). And if there are more than 10 digits
+    remaining after that, it means you have a carry. A carry is just used to make the above table
+    one character longer on the next iteration (since a longer left side results in a higher digit
+    being looked up).</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; Fortunately I was able to find an algorithm and format
+    for the tables that allowed the same code to work the same way for subtraction -- but just
+    using <code>"9876543210;0123456789"</code> for the first table instead. It was one of several
+    eureka moments, as I found the borrow was able to work the exact same way as the carry did for
+    addition. The add/sub was probably the hardest, most frustrating part of the whole script since
+    there were so many ways to go. And it's also the ugliest part of the code (if you could call
+    any of it pretty :).</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; The multiplication routine starts with a loop that
+    creates a product template (e.g., position of decimal point) based on the current scale and the
+    scale (number of fraction digits) in each factor. I found a technique in Knuth for multiplying
+    from right to left getting a product digit at a time, instead of keeping all the intermediate
+    products as you do on paper. It's just multiplying the individual digits in a different order
+    allowing you to progress a column at a time leftwards instead of a row at a time -- nothing
+    earth-shattering. Then to multiply two digits, say <i>3*5</i>, you just generate an analog
+    string of length 3 (the first factor) using the lookup-table trick and repeat it 10 times to
+    get this intermediate lookup table:</p>
+<pre>
+    9aaa8aaa7aaa6aaa5aaa4aaa3aaa2aaa1aaa0
+</pre>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; Then you find the other factor (5) in this table and take
+    all the <code>a</code>'s past that point. There will be 15 <code>a</code>'s left (3*5). These
+    digit products are kept in a reduced analog format where, for example, the number 427 would be
+    represented as <code>ccccbbaaaaaaa</code>. This allows each digit product to be efficiently
+    added to the next. You just concatenate the <code>a</code>'s from the next, if there are more
+    than 10 you turn the first 10 into a <code>b</code>, and if there are more than 10
+    <code>b</code>'s you turn the first 10 <code>b</code>'s into a <code>c</code>. When done adding
+    all the digit products for the current column, you turn the <code>a</code>'s (one's place) back
+    into a digit using a lookup table and put it in the product. And the remaining <code>b</code>'s
+    and <code>c</code>'s (tens and hundreds) are carried over to be included in the next column as
+    <code>a</code>'s and <code>b</code>'s (ones and tens). When there are no <code>a</code>'s or
+    <code>b</code>'s remaining carried over, your product is complete.</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; For division, Knuth was a real life-saver. He covered
+    something called Newton's 2nd-order reciprocal method where you can calculate the reciprocal of
+    any number (<i>n</i>) by taking an initial guess (<i>g</i>) and then repeatedly doing <i>g = 2g
+    - ngg</i> on it until it stabilizes. (And the multiplication and subtraction routines needed
+    for this are already available.) Then you just multiply by this reciprocal when done. The
+    <code>sed</code> loop in the divide routine is just used to get an initial guess that's in the
+    right ball park. Basically, if you have an n&gt;1 that has 30 digits to the left of the decimal
+    point, the initial guess is <i>.000...0001</i> with 30 zeros to the right of the decimal point.
+    And vice versa. At this point control is passed to <code>dc</code> commands pushed on the input
+    stack to compute the quotient using Newton's method.</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; Likewise, I used Newton's square root algorithm too. I
+    first use <code>sed</code> to generate an initial guess (g) by simply deleting half the digits
+    in the number n (or half the leading zeros if n &lt; 1). Then boot-strap to <code>dc</code>
+    code which repeatedly does <i>g = (g + n/g) / 2</i> until <i>g</i> stops decreasing. Amazingly,
+    the very first test of this routine (<code>8k2v</code>) was right on the mark even though the
+    square root and divide routines were still buggy. A testament to the reliable convergence of
+    Newton's algorithm I think. Ken Pizzini (<acronym>GNU</acronym> <code>sed</code> POC) later found a
+    precision glitch in certain cases when the scale is 0 (e.g., <code>16v</code>,
+    <code>224v</code>) that I corrected in the <a href="https://web.archive.org/web/20211026153130/http://www.perl.com/language/ppt/src/dc/">Perl
+    version</a> and in the 1.1 version.</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; I could have saved a few <code>sed</code> commands by
+    implementing the exponential function totally in <code>dc</code> using a binary algorithm. But
+    I already had a version coded in <code>sed</code> that calculates the power using an
+    interesting decimal lookup-table method (where what you're looking up is actually the
+    <code>dc</code> code needed to raise a number to a given power from 0 to 9), and didn't want to
+    throw all that work out. In this algorithm, <i>x^736</i> is computed as <i>((x^7) ^ 10 * x^3) ^
+    10 * x^6</i>, which averages 7.1 multiplies per digit. One of the hardest parts of this
+    function was figuring out the algorithm to calculate the precision of the result correctly
+    (something <acronym>GNU</acronym> <code>dc</code> didn't get right (at the time)). That's what a
+    lot of the <code>dc</code> code here is doing. As in most places, not being a mathematician, I
+    figured this out empirically by just writing a bunch of examples on paper and seeing what
+    precision was needed in the various cases.</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; When I started out on the <code>dc.sed</code> adventure,
+    I never planned to include the radix conversions, thinking that part was just too complex and
+    I'd never be able to fit it in the 199-command <code>sed</code> limit even if it were possible.
+    But completing the above fundamental routines freed up my mind to rethink this. I found that
+    the same techniques of boot- strapping most of the work up to higher-level <code>dc</code> code
+    could be used effectively here too. The routine to convert non-decimal input to decimal
+    required some initial lookup-table <code>sed</code> code to generate the <code>dc</code>
+    commands used to do the actual conversion. But it turned out the opposite conversion to a
+    non-decimal output base could be done *entirely* in <code>dc</code> -- albeit a 6-line-long
+    <code>dc</code> incantation. (Commented <code>dc</code> source for this is available <a href="output.dc">here</a>.) The first test of this code was <code><nobr>100o
+    _1234567.1234567p</nobr></code> (at 1:43am Feb 2, 1997 :), and surprisingly worked
+    flawlessly.</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; A few words on the other routines, for completeness...
+    The string input routine is mainly matching [arbitrarily-nested [brackets]] to find the end of
+    the string, which may involve reading multiple lines of input. I added array routines
+    implemented in boot-strapped <code>dc</code>, but later thought they might actually be better
+    implemented in <code>sed</code> instead. One of my favorite sections is the :count routine
+    which is used for the three <code>dc</code> functions that need to count things. I optimized
+    quite a bit of code out of here and am pretty sure it can't be reduced even one character
+    further. It uses the same basic analog counting method as is used in the middle of the multiply
+    routine. The register routines were one of the first things added to <code>dc.sed</code>, and
+    are really what got me interested when I envisioned how they could be implemented in
+    <code>sed</code>.</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; The :break routine (<code>Q</code> command) involves a
+    decrement counter to remove n items from the input stack, using yet another lookup table
+    algorithm. (The :trunc and multiplication precision routines also involve loops controlled by
+    decrement counters that use the same algorithm. :trunc, incidentally, is a special
+    <code>dc</code> function that is kind of the opposite of the boot-strapping-<code>dc</code>
+    technique -- I used it in several places to "call back" to <code>sed</code> to do a function
+    that couldn't be done in <code>dc</code>.)</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; <code>dc.sed</code> was all designed and coded on scratch
+    paper. Although to a computer scientist it may seem weird doing math using only string
+    manipulations, I think it's best compared to the problem of designing the mechanical
+    calculators (some of which were sophisticated enough to include square root functions). Though
+    I didn't have to worry about inertia. And besides the enjoyment of the hack challenge, I can
+    think of one reusable part: the boot-strapping-<code>dc</code> technique would actually be
+    practical to simplify a C implementation of <code>dc</code>.</p>
+
+    <p align="justify">&nbsp;&nbsp;&nbsp; See Also:</p>
+
+    <blockquote>
+      <dl>
+        <dt><a href="https://web.archive.org/web/20211026153130/http://sed.sf.net/grabbag/scripts/">http://sed.sf.net/grabbag/scripts/</a></dt>
+
+        <dd>Current location of <code>dc.sed</code> 1.1</dd>
+
+        <dt><a href="https://web.archive.org/web/20211026153130/http://sed.sf.net/grabbag/tutorials/">http://sed.sf.net/grabbag/tutorials/</a></dt>
+
+        <dd>Nitty-gritty details of lookup tables and counters in <code>sed</code></dd>
+
+        <dt><a href="https://web.archive.org/web/20211026153130/http://www.perl.com/language/ppt/src/dc/">http://www.perl.com/language/ppt/src/dc/</a></dt>
+
+        <dd>dc.pl - the Perl translation</dd>
+      </dl>
+    </blockquote>
+  </body>
+</html>
+
+<!--
+     FILE ARCHIVED ON 15:31:30 Oct 26, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 22:42:08 Apr 26, 2023.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 79.783
+  exclusion.robots: 0.098
+  exclusion.robots.policy: 0.088
+  cdx.remote: 0.067
+  esindex: 0.008
+  LoadShardBlock: 54.671 (3)
+  PetaboxLoader3.datanode: 3526.23 (6)
+  load_resource: 3685.107 (2)
+  PetaboxLoader3.resolve: 143.122 (2)
+  loaddict: 51.396
+-->

--- a/grabbag/scripts/dc_overview.htm
+++ b/grabbag/scripts/dc_overview.htm
@@ -1,15 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html lang="en">
-  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
-<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
-<script type="text/javascript">
-  __wm.init("https://web.archive.org/web");
-  __wm.wombat("http://sed.sourceforge.net/grabbag/scripts/dc_overview.htm","20211026153130","https://web.archive.org/","web","/_static/",
-	      "1635262290");
-</script>
-<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
-<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
-<!-- End Wayback Rewrite JS Include -->
+  <head>
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>Overview of How the dc.sed Script Works</title>
@@ -261,25 +252,3 @@
     </blockquote>
   </body>
 </html>
-
-<!--
-     FILE ARCHIVED ON 15:31:30 Oct 26, 2021 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 22:42:08 Apr 26, 2023.
-     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
-
-     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
-     SECTION 108(a)(3)).
--->
-<!--
-playback timings (ms):
-  captures_list: 79.783
-  exclusion.robots: 0.098
-  exclusion.robots.policy: 0.088
-  cdx.remote: 0.067
-  esindex: 0.008
-  LoadShardBlock: 54.671 (3)
-  PetaboxLoader3.datanode: 3526.23 (6)
-  load_resource: 3685.107 (2)
-  PetaboxLoader3.resolve: 143.122 (2)
-  loaddict: 51.396
--->

--- a/grabbag/scripts/dc_overview.htm
+++ b/grabbag/scripts/dc_overview.htm
@@ -176,7 +176,7 @@
     square root and divide routines were still buggy. A testament to the reliable convergence of
     Newton's algorithm I think. Ken Pizzini (<acronym>GNU</acronym> <code>sed</code> POC) later found a
     precision glitch in certain cases when the scale is 0 (e.g., <code>16v</code>,
-    <code>224v</code>) that I corrected in the <a href="https://web.archive.org/web/20211026153130/http://www.perl.com/language/ppt/src/dc/">Perl
+    <code>224v</code>) that I corrected in the <a href="http://www.perl.com/language/ppt/src/dc/">Perl
     version</a> and in the 1.1 version.</p>
 
     <p align="justify">&nbsp;&nbsp;&nbsp; I could have saved a few <code>sed</code> commands by
@@ -245,7 +245,7 @@
 
         <dd>Nitty-gritty details of lookup tables and counters in <code>sed</code></dd>
 
-        <dt><a href="https://web.archive.org/web/20211026153130/http://www.perl.com/language/ppt/src/dc/">http://www.perl.com/language/ppt/src/dc/</a></dt>
+        <dt><a href="http://www.perl.com/language/ppt/src/dc/">http://www.perl.com/language/ppt/src/dc/</a></dt>
 
         <dd>dc.pl - the Perl translation</dd>
       </dl>

--- a/grabbag/scripts/dc_overview.htm
+++ b/grabbag/scripts/dc_overview.htm
@@ -237,11 +237,11 @@
 
     <blockquote>
       <dl>
-        <dt><a href="https://web.archive.org/web/20211026153130/http://sed.sf.net/grabbag/scripts/">http://sed.sf.net/grabbag/scripts/</a></dt>
+        <dt><a href="/grabbag/scripts/">http://sed.sf.net/grabbag/scripts/</a></dt>
 
         <dd>Current location of <code>dc.sed</code> 1.1</dd>
 
-        <dt><a href="https://web.archive.org/web/20211026153130/http://sed.sf.net/grabbag/tutorials/">http://sed.sf.net/grabbag/tutorials/</a></dt>
+        <dt><a href="/grabbag/tutorials/">http://sed.sf.net/grabbag/tutorials/</a></dt>
 
         <dd>Nitty-gritty details of lookup tables and counters in <code>sed</code></dd>
 

--- a/grabbag/scripts/index.html
+++ b/grabbag/scripts/index.html
@@ -1,15 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html lang="en">
-  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
-<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
-<script type="text/javascript">
-  __wm.init("https://web.archive.org/web");
-  __wm.wombat("http://sed.sourceforge.net/grabbag/scripts/","20210916192909","https://web.archive.org/","web","/_static/",
-	      "1631820549");
-</script>
-<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
-<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
-<!-- End Wayback Rewrite JS Include -->
+  <head>
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>Seder's grab bag - scripts</title>
@@ -756,24 +747,3 @@
     </div>
   </body>
 </html>
-
-<!--
-     FILE ARCHIVED ON 19:29:09 Sep 16, 2021 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 22:36:51 Apr 26, 2023.
-     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
-
-     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
-     SECTION 108(a)(3)).
--->
-<!--
-playback timings (ms):
-  captures_list: 116.405
-  exclusion.robots: 0.087
-  exclusion.robots.policy: 0.077
-  cdx.remote: 0.06
-  esindex: 0.01
-  LoadShardBlock: 66.002 (3)
-  PetaboxLoader3.datanode: 76.825 (4)
-  load_resource: 107.898
-  PetaboxLoader3.resolve: 61.484
--->

--- a/grabbag/scripts/index.html
+++ b/grabbag/scripts/index.html
@@ -146,7 +146,7 @@
       <dd>
         <div class="last">
           Changes TeX-like tags (<tt>abc{...}</tt>) to XML-like tags
-          (<tt>&lt;abc&gt;...&lt;/abc&gt;</tt>). An interesting proof of concept script by <a href="https://web.archive.org/web/20210916192909/mailto:bitterberg@gmx.de">Tilmann Bitterberg</a>, supporting nested tags and much more.
+          (<tt>&lt;abc&gt;...&lt;/abc&gt;</tt>). An interesting proof of concept script by <a href="mailto:bitterberg@gmx.de">Tilmann Bitterberg</a>, supporting nested tags and much more.
         </div>
       </dd>
 
@@ -157,7 +157,7 @@
           This script takes a complex configuration file format (supporting almost every quoting
           style in the Bourne shell) and encodes each value that the script defines with
           "dangerous" characters properly escaped; full documentation is contained in the download.
-          This script by <a href="https://web.archive.org/web/20210916192909/mailto:Nathan.Ryan@Colorado.EDU">Nathan D. Ryan</a> shows how to
+          This script by <a href="mailto:Nathan.Ryan@Colorado.EDU">Nathan D. Ryan</a> shows how to
           do complex conversions with <code>sed</code>.
         </div>
       </dd>
@@ -223,7 +223,7 @@
 
       <dd>
         <div class="last">
-          This script, by <a href="https://web.archive.org/web/20210916192909/mailto:tilmann@bitterberg.de">Tilman Bitterberg</a>, adds an
+          This script, by <a href="mailto:tilmann@bitterberg.de">Tilman Bitterberg</a>, adds an
           index of links to an <acronym>HTML</acronym> file: similar to `<code>lynx -dump</code>', but
           preserving the <acronym>HTML</acronym> tags in the file.
         </div>
@@ -300,7 +300,7 @@
 
       <dd>
         <div class="last">
-          Another masterpiece by <a href="https://web.archive.org/web/20210916192909/mailto:gsu@nsa.gov">Greg Ubben</a>. The link above works with all sed implementations,
+          Another masterpiece by <a href="mailto:gsu@nsa.gov">Greg Ubben</a>. The link above works with all sed implementations,
           while <a href="expand-new.sed">this version</a> only works with GNU sed
           3.02.80 or <a href="/grabbag/ssed/">ssed</a>, but is more readable because it does
           not contain control characters.
@@ -385,7 +385,7 @@
 
       <dt><a href="remccoms2.sh.txt">Strip C comments (2/4)</a> <span class="rating">(<tt>***</tt>)</span></dt>
 
-      <dd>This script, by <a href="https://web.archive.org/web/20210916192909/mailto:stewart.ravenhall@ukonline.co.uk">Stewart Ravenhall</a>,
+      <dd>This script, by <a href="mailto:stewart.ravenhall@ukonline.co.uk">Stewart Ravenhall</a>,
       unlike the previous one handles comments surrounded by code.</dd>
 
       <dt><a href="remccoms3.sed">Strip C/C++ comments (3/4)</a>
@@ -393,7 +393,7 @@
 
       <dd>
         <div class="last">
-          This script, by <a href="https://web.archive.org/web/20210916192909/mailto:brian.hiles@rocketmail.com">Brian Hiles</a>, handles C
+          This script, by <a href="mailto:brian.hiles@rocketmail.com">Brian Hiles</a>, handles C
           and C++ (<tt>//</tt>) comments and, unlike the previous ones, correctly skips comments
           inside strings. It shows a very interesting trick to build a line piecewise in hold
           space, which eases more complicated parsing tasks.
@@ -414,7 +414,7 @@
 
       <dd>
         <div class="last">
-          Indents the output of <code>find -type d</code> into a nice tree format. Thanks to <a href="https://web.archive.org/web/20210916192909/mailto:stewart.ravenhall@ukonline.co.uk">Stewart Ravenhall</a>.
+          Indents the output of <code>find -type d</code> into a nice tree format. Thanks to <a href="mailto:stewart.ravenhall@ukonline.co.uk">Stewart Ravenhall</a>.
         </div>
       </dd>
 
@@ -441,7 +441,7 @@
           Very comprehensive suite of filters by Robert Marks which perform a large number
           of beautifying operations on text files prior to processing by <code>troff</code>. These
           scripts were used to produce camera-ready output for the <cite>Australian School of
-          Management</cite> between 1985 and 1995. You can download a <a href="polish.tar.gz">gzipped tar archive</a> of the scripts, or individual scripts: <a href="polish0.sed">polish0.sed</a>, <a href="polish1.sed">polish1.sed</a>, <a href="polish2.sed">polish2.sed</a>, <a href="polish3.sed">polish3.sed</a>, <a href="polish4.sed">polish4.sed</a>, <a href="polish5.sed">polish5.sed</a>, <a href="polish6.sed">polish6.sed</a>, <a href="polish7.sed">polish7.sed</a>, <a href="polish8.sed">polish8.sed</a>, <a href="polish9.sed">polish9.sed</a>, or visit <a href="https://web.archive.org/web/20210916192909/http://www.agsm.unsw.edu.au/~bobm/odds+ends/scripts.html">Robert's Web site</a>.
+          Management</cite> between 1985 and 1995. You can download a <a href="polish.tar.gz">gzipped tar archive</a> of the scripts, or individual scripts: <a href="polish0.sed">polish0.sed</a>, <a href="polish1.sed">polish1.sed</a>, <a href="polish2.sed">polish2.sed</a>, <a href="polish3.sed">polish3.sed</a>, <a href="polish4.sed">polish4.sed</a>, <a href="polish5.sed">polish5.sed</a>, <a href="polish6.sed">polish6.sed</a>, <a href="polish7.sed">polish7.sed</a>, <a href="polish8.sed">polish8.sed</a>, <a href="polish9.sed">polish9.sed</a>, or visit <a href="http://www.agsm.unsw.edu.au/~bobm/odds+ends/scripts.html">Robert's Web site</a>.
         </div>
       </dd>
 
@@ -506,7 +506,7 @@
       </dd>
 
       <dt><a href="cgrep.sh.txt">Extract regular expressions and print the
-      context</a> - by <a href="https://web.archive.org/web/20210916192909/mailto:gsu@nsa.gov">Greg Ubben</a> <span class="rating">(<tt>****</tt>)</span></dt>
+      context</a> - by <a href="mailto:gsu@nsa.gov">Greg Ubben</a> <span class="rating">(<tt>****</tt>)</span></dt>
 
       <dd>
         <div class="last">
@@ -516,7 +516,7 @@
       </dd>
 
       <dt><a href="fullgrep.sh.txt">Extract regular expressions and print the
-      context</a> - thanks to <a href="https://web.archive.org/web/20210916192909/mailto:hartmut.schaefer@zkb.ch">Hartmut Schaefer</a> <span class="rating">(<tt>***</tt>)</span></dt>
+      context</a> - thanks to <a href="mailto:hartmut.schaefer@zkb.ch">Hartmut Schaefer</a> <span class="rating">(<tt>***</tt>)</span></dt>
 
       <dd>
         <div class="last">
@@ -584,7 +584,7 @@
 
       <dd>
         <div class="last">
-          This script from sed guru <a href="https://web.archive.org/web/20210916192909/mailto:gsu@nsa.gov">Greg Ubben</a> is a full implementation of the Unix desktop
+          This script from sed guru <a href="mailto:gsu@nsa.gov">Greg Ubben</a> is a full implementation of the Unix desktop
           calculator <code>dc</code>. dc is an arbitrary precision, multi-base, stacking calculator. Here
           is <a href="dc_intro.txt">a quick guide to it</a>, which Greg posted to
           seders, and an <a href="dc_overview.htm">overview of how it works</a>.
@@ -604,7 +604,7 @@
           tables</a>.
         </div>
         <div class="last">
-           Note that this is <em>not</em> the script explained in <a href="https://web.archive.org/web/20210916192909/mailto:gsu@nsa.gov">Greg Ubben</a>'s <a href="/grabbag/tutorials/greg_add.txt">Adding a list of decimal numbers</a> (on the <a href="/grabbag/tutorials/">tutorials page</a>); Greg's script is found directly in the
+           Note that this is <em>not</em> the script explained in <a href="mailto:gsu@nsa.gov">Greg Ubben</a>'s <a href="/grabbag/tutorials/greg_add.txt">Adding a list of decimal numbers</a> (on the <a href="/grabbag/tutorials/">tutorials page</a>); Greg's script is found directly in the
           tutorial.
         </div>
       </dd>
@@ -642,7 +642,7 @@
 
       <dd>
         <div class="last">
-          A totally useless but quite funny script by <a href="https://web.archive.org/web/20210916192909/mailto:ccb@club-internet.fr">Christophe Blaess</a>: a Turing Machine is able to execute
+          A totally useless but quite funny script by <a href="mailto:ccb@club-internet.fr">Christophe Blaess</a>: a Turing Machine is able to execute
           any computable task (albeit slowly and painfully)... so <code>sed</code> can perform any computable
           task!!! Here is a <a href="turing.txt">description</a> of the input file
           format, including a sample automaton to increment binary numbers.
@@ -650,7 +650,7 @@
       </dd>
 
       <dt><a href="sokoban.sed"><tt>sed</tt> <i>sokoban</i></a> by
-       <a href="https://web.archive.org/web/20210916192909/mailto:aurelio@conectiva.com.br">Aurelio Marinho Jargas</a>
+       <a href="mailto:aurelio@conectiva.com.br">Aurelio Marinho Jargas</a>
        <span class="rating">(<tt>*****</tt>)</span></dt>
 
       <dd>
@@ -662,7 +662,7 @@
       </dd>
 
       <dt><a href="arkanoid.sed"><tt>sed</tt> <i>arkanoid</i></a> by
-       <a href="https://web.archive.org/web/20210916192909/mailto:aurelio@conectiva.com.br">Aurelio Marinho Jargas</a>
+       <a href="mailto:aurelio@conectiva.com.br">Aurelio Marinho Jargas</a>
        <span class="rating">(<tt>*****</tt>)</span></dt>
 
       <dd>
@@ -686,7 +686,7 @@
 
       <dd>
         <div class="last">
-          This scripts convert <a href="https://web.archive.org/web/20210916192909/http://www.muppetlabs.com/~breadbox/bf">Brainf**k</a>
+          This scripts convert <a href="http://www.muppetlabs.com/~breadbox/bf">Brainf**k</a>
           programming language to C, ready to be compiled to machine code.
         </div>
       </dd>
@@ -713,7 +713,7 @@
     <h3 id="sdeb"><code>sed</code> debuggers</h3>
 
     <dl>
-      <dt><a href="sd.py.txt">Python sed debugger</a> by <a href="https://web.archive.org/web/20210916192909/mailto:aurelio@conectiva.com.br">Aurelio Marinho Jargas</a></dt>
+      <dt><a href="sd.py.txt">Python sed debugger</a> by <a href="mailto:aurelio@conectiva.com.br">Aurelio Marinho Jargas</a></dt>
 
       <dd>
         <div>
@@ -731,7 +731,7 @@
         </div>
       </dd>
 
-      <dt><a href="sd.ksh.txt">Korn shell debugger</a> by <a href="https://web.archive.org/web/20210916192909/mailto:brian_hiles@rocketmail.com">Brian Hiles</a></dt>
+      <dt><a href="sd.ksh.txt">Korn shell debugger</a> by <a href="mailto:brian_hiles@rocketmail.com">Brian Hiles</a></dt>
 
       <dd>
         <div class="last">

--- a/grabbag/scripts/index.html
+++ b/grabbag/scripts/index.html
@@ -1,0 +1,779 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("http://sed.sourceforge.net/grabbag/scripts/","20210916192909","https://web.archive.org/","web","/_static/",
+	      "1631820549");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
+    <title>Seder's grab bag - scripts</title>
+    <style type="text/css">@import url(/web/20210916192909cs_/http://sed.sourceforge.net/grabbag/seders.css);</style>
+  </head>
+
+  <body>
+    <div class="titolo">
+      <div class="sezioni">
+      <h1><a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/"><span>seder's</span> grab bag</a></h1>
+      <ul>
+        <li><a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/scripts/">scripts</a></li>
+        <li><a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/">tutorials</a></li>
+        <li><a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/seders/">seders</a></li>
+        <li><a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/ssed/">ssed</a></li>
+        <li><a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/links/">links</a></li>
+      </ul>
+      </div>
+    </div>
+
+    <ul class="menu">
+      <li><a href="#fima">Filename manipulation</a></li>
+      <li><a href="#fico">File conversion</a></li>
+      <li><a href="#html"><acronym>HTML</acronym> utilities</a></li>
+      <li><a href="#txfo">Text formatting</a></li>
+      <li><a href="#beau">Beautifiers</a></li>
+      <li><a href="#tabu">Extraction and tabulation</a></li>
+      <li><a href="#misc">Miscellaneous</a></li>
+      <li><a href="#sdeb"><code>sed</code> debuggers (!)</a></li>
+    </ul>
+
+    <div class="testo">
+    <h2>Script Archive</h2>
+
+    <div class="warning">
+      It is sometimes necessary to remove comments (preceded by #), since this is not
+      universally legal syntax.
+    </div>
+
+    <p>I tried to classify these scripts according to their cleverness and interest when learning how
+     to use <code>sed</code>. Clever ones are not always faster; sometimes, more complicated
+     techniques are also slower. Sometimes, longer and more complex scripts are mostly boilerplate,
+     thus less interesting for the <code>sed</code> `student' and rated with fewer stars; readability also
+     and documentation influenced the rating.</p>
+
+    <p>
+      <tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt> <span class="rating">(<tt>*</tt>)</span> = very basic, little to learn <br>
+      <tt>&nbsp;&nbsp;&nbsp;&nbsp;</tt> <span class="rating">(<tt>**</tt>)</span> = does some simple processing <br>
+      <tt>&nbsp;&nbsp;&nbsp;</tt> <span class="rating">(<tt>***</tt>)</span> = shows some nice techniques <br>
+      <tt>&nbsp;&nbsp;</tt> <span class="rating">(<tt>****</tt>)</span> = shows advanced techniques, such as lookup tables <br>
+      <tt>&nbsp;</tt> <span class="rating">(<tt>*****</tt>)</span> = that's <em>extreme</em> <code>sed</code>! 
+    </p>
+
+    <h3 id="fima">Filename manipulation</h3>
+
+    <dl>
+      <dt><a href="tolower.sed">Lowercase filenames (filter)</a> <span class="rating">(<tt>***</tt>)</span></dt>
+      <dt>
+       <a href="toupper.sed">Uppercase filenames (filter)</a> <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Lowercase/uppercase list of filenames supplied from STDIN. Makes a list of
+          <samp>mv</samp> commands.
+         <div class="example">
+           <strong>Example:</strong>
+           <samp>find /mnt/zeus/docs | tolower.sed | sh -x</samp>
+         </div>
+        </div>
+      </dd>
+
+      <dt><a href="tolower2.sed">Lowercase filenames (application)</a>
+      <span class="rating">(<tt>***</tt>)</span></dt>
+      <dt><a href="toupper2.sed">Uppercase filenames (application)</a>
+      <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Lowercase/uppercase list of filenames supplied as command line arguments. Again, makes a
+          list of <samp>mv</samp> commands. This version operates on files in the <em>current</em>
+          directory only.
+          <div class="example">
+            <strong>Example:</strong>
+            <samp>down *.HTM *.INC *.sed</samp>
+          </div>
+        </div>
+      </dd>
+
+      <dt><a href="fbasename.sed">Print basename of files</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Remove the directory prefix from a file path, and print remaining element. Like Unix
+          <samp>basename</samp>, but reads data from a file or stdin. Could easily be adapted for
+          DOS conventions.
+        </div>
+      </dd>
+
+      <dt><a href="fdirname.sed">Print path of files</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Remove the filename from a file path, and print remaining elements. Like Unix
+          <samp>dirname</samp>, but reads data from a file or stdin. Easily adapted to DOS
+          conventions.
+        </div>
+      </dd>
+    </dl>
+
+    <h3 id="fico">File conversion</h3>
+
+    <dl>
+      <dt><a href="crlf.tar.gz">Convert DOS files for UNIX and vice versa</a>
+      <span class="rating">(<tt>*</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Changes DOS end-of-lines to UNIX end-of-lines (to be ran under UNIX). Provided in a
+          single gzipped tar file to avoid that the server screws up the control characters.
+        </div>
+      </dd>
+
+      <dt><a href="splitdig.sed">Split digest</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Recreates original email messages from a list digest. The author says this should work
+          `at least for digests generated by Majordomo and #listserv, and FAQs using <code>minimal
+          digest format.</code>'
+        </div>
+      </dd>
+
+      <dt><a href="rot13.sed"><tt>rot13</tt></a> <span class="rating">(<tt>*</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          The simplest symmetric cypher in the world...
+        </div>
+      </dd>
+
+      <dt><a href="tex2xml.sed">TeX to XML converter</a> <span class="rating">(<tt>*****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Changes TeX-like tags (<tt>abc{...}</tt>) to XML-like tags
+          (<tt>&lt;abc&gt;...&lt;/abc&gt;</tt>). An interesting proof of concept script by <a href="https://web.archive.org/web/20210916192909/mailto:bitterberg@gmx.de">Tilmann Bitterberg</a>, supporting nested tags and much more.
+        </div>
+      </dd>
+
+      <dt><a href="config.sed">Expand quoted strings</a> <span class="rating">(<tt>*****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          This script takes a complex configuration file format (supporting almost every quoting
+          style in the Bourne shell) and encodes each value that the script defines with
+          "dangerous" characters properly escaped; full documentation is contained in the download.
+          This script by <a href="https://web.archive.org/web/20210916192909/mailto:Nathan.Ryan@Colorado.EDU">Nathan D. Ryan</a> shows how to
+          do complex conversions with <code>sed</code>.
+        </div>
+      </dd>
+    </dl>
+
+    <h3 id="html"><acronym>HTML</acronym> utilities</h3>
+
+    <dl>
+      <dt><a href="txt2html.sed">Text -&gt; <acronym>HTML</acronym></a>
+      <span class="rating">(<tt>*</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Converts preformatted text to <acronym>HTML</acronym> ready for viewing.
+        </div>
+      </dd>
+
+      <dt><a href="italbold.sed">Insert boldface/italic tags</a>
+      <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Takes input files with two different "toggle switches" such as the _underscore_ and
+          *asterisk*, and convert them into something like <cite>&lt;i&gt;italic&lt;/i&gt;</cite>
+          and <cite>&lt;b&gt;boldface&lt;/b&gt;</cite> in the output. A nice exercise would be to
+          merge this with <a href="untroff.sed">untroff.sed</a> and obtain a nice
+          troff-to-<acronym>HTML</acronym> sed script.
+        </div>
+      </dd>
+
+      <dt><a href="iso2html.sed">ISO8859-1 -&gt; <acronym>HTML</acronym></a>
+      <span class="rating">(<tt>*</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Convert ISO Latin 1 characters (eg: &eacute;, &pound;, &yen;, &frac12;) to their
+          equivalent <acronym>HTML</acronym> character entitities.
+        </div>
+      </dd>
+
+      <dt><a href="html2iso.sed"><acronym>HTML</acronym> -&gt; ISO8859-1</a>
+      <span class="rating">(<tt>*</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Convert <acronym>HTML</acronym> character entities to their ISO Latin 1 equivalent.
+        </div>
+      </dd>
+
+      <dt><a href="html_lc.sed">Lowercase <acronym>HTML</acronym> tags</a>
+      <span class="rating">(<tt>****</tt>)</span></dt>
+      <dt><a href="html_uc.sed">Uppercase <acronym>HTML</acronym> tags</a>
+      <span class="rating">(<tt>****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Change case of <acronym>HTML</acronym> tags, preserving attributes.
+        </div>
+      </dd>
+
+      <dt><a href="indexhtml.sed">Index <acronym>HTML</acronym> links</a>
+      <span class="rating">(<tt>****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          This script, by <a href="https://web.archive.org/web/20210916192909/mailto:tilmann@bitterberg.de">Tilman Bitterberg</a>, adds an
+          index of links to an <acronym>HTML</acronym> file: similar to `<code>lynx -dump</code>', but
+          preserving the <acronym>HTML</acronym> tags in the file.
+        </div>
+      </dd>
+
+      <dt><a href="strip_html_comments.sed">Strip <acronym>HTML</acronym> comments</a>
+      <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Remove all commented material from <acronym>HTML</acronym>
+        </div>
+      </dd>
+
+      <dt><a href="list_urls.sed">Extract URLs from <acronym>HTML</acronym></a>
+      <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Print all URLs (even commented ones) and associated ALT comments found in an
+          <acronym>HTML</acronym> file, formatted as: <samp>URL|comment</samp>.
+        </div>
+      </dd>
+
+      <dt><a href="get_html_title.sed">Extract title from <acronym>HTML</acronym></a>
+      <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Print the <samp>TITLE</samp> (or the first <samp>H[0-7]</samp> heading located) of an
+          <acronym>HTML</acronym> document.
+        </div>
+      </dd>
+    </dl>
+
+    <h3 id="txfo">Text formatting</h3>
+
+    <dl>
+      <dt><a href="cflword1.sed">Capitalise words 1/5</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>Capitalises the first letter of each word.</dd>
+
+      <dt><a href="cflword2.sed">Capitalise words 2/5</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>A first approach to doing it faster.</dd>
+
+      <dt><a href="cflword3.sed">Capitalise words 3/5</a> <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>A cleaner implementation of the idea in <a href="cflword2.sed">cflword2.sed</a></dd>
+
+      <dt><a href="cflword4.sed">Capitalise words 4/5</a> <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>This gets weirdo!</dd>
+
+      <dt><a href="cflword5.sed">Capitalise words 5/5</a> <span class="rating">(<tt>****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          And finally, we capitalise words with <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/lookup_tables.txt">lookup tables.</a>
+        </div>
+      </dd>
+    </dl>
+
+    <dl>
+      <dt><a href="fmt.sed">Formats text lines</a> <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Formats text so that each line is shorter than 40 characters.
+        </div>
+      </dd>
+
+      <dt><a href="expand.sed">Expand tabs to spaces</a> <span class="rating">(<tt>****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Another masterpiece by <a href="https://web.archive.org/web/20210916192909/mailto:gsu@nsa.gov">Greg Ubben</a>. The link above works with all sed implementations,
+          while <a href="expand-new.sed">this version</a> only works with GNU sed
+          3.02.80 or <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/ssed/">ssed</a>, but is more readable because it does
+          not contain control characters.
+        </div>
+      </dd>
+
+      <dt><a href="revchr_1.sed">Reverse text</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>Reverses the order of characters on each line of input.</dd>
+
+      <dt><a href="revchr_2.sed">Reverse text</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          A faster version.
+        </div>
+      </dd>
+
+      <dt><a href="revlines.sed">Reverse file</a> <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Reverses the line order of a file, subject to the size of the hold buffer.
+        </div>
+      </dd>
+
+      <dt><a href="joinfile.sed">Join lines</a> <span class="rating">(<tt>*</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Joins all input on a single line.
+        </div>
+      </dd>
+
+      <dt><a href="undblspc.sed">Un-double-space lines</a> <span class="rating">(<tt>*</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Change double-spaced lines to single-spaced.
+        </div>
+      </dd>
+
+      <dt><a href="centre_1.sed">Centre lines 1/2</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>Centres lines for an 80-column device. Easily adapted to different widths.</dd>
+
+      <dt><a href="centre_2.sed">Centre lines 2/2</a> <span class="rating">(<tt>*</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          A different and more CPU-intensive approach.
+        </div>
+      </dd>
+
+      <dt><a href="cat-s.sed">Squeeze blank lines</a> <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Replace consecutive blank lines with one line, so that at most one empty line separates
+          two non-empty lines. Emulates <code>cat -s</code>.
+        </div>
+      </dd>
+    </dl>
+
+    <h3 id="beau">Beautifiers</h3>
+
+    <dl>
+      <dt><a href="masm2gas.sed">Intel assembler -&gt; UNIX assembler</a>
+      <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Converts Intel 386 assembly (<code>nasm</code>) code to Unix 386 assembly (<code>gas</code>) code.
+        </div>
+      </dd>
+
+      <dt><a href="remccoms1.sed">Strip C comments (1/4)</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>This one is the first script in a series of scripts that do the same task in more and
+      more sophisticated ways. This handles multiline comments, but not multiple comments in a
+      line</dd>
+
+      <dt><a href="remccoms2.sh.txt">Strip C comments (2/4)</a> <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>This script, by <a href="https://web.archive.org/web/20210916192909/mailto:stewart.ravenhall@ukonline.co.uk">Stewart Ravenhall</a>,
+      unlike the previous one handles comments surrounded by code.</dd>
+
+      <dt><a href="remccoms3.sed">Strip C/C++ comments (3/4)</a>
+      <span class="rating">(<tt>****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          This script, by <a href="https://web.archive.org/web/20210916192909/mailto:brian.hiles@rocketmail.com">Brian Hiles</a>, handles C
+          and C++ (<tt>//</tt>) comments and, unlike the previous ones, correctly skips comments
+          inside strings. It shows a very interesting trick to build a line piecewise in hold
+          space, which eases more complicated parsing tasks.
+        </div>
+      </dd>
+
+      <dt><a href="indentls.sed">Beautify directory listing (UNIX)</a>
+      <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Indents the output of <code>ls -lR</code> according to the depth of each directory. Makes
+          output far easier to read.
+        </div>
+      </dd>
+
+      <dt><a href="dtree.sh.txt">Directory tree (UNIX)</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Indents the output of <code>find -type d</code> into a nice tree format. Thanks to <a href="https://web.archive.org/web/20210916192909/mailto:stewart.ravenhall@ukonline.co.uk">Stewart Ravenhall</a>.
+        </div>
+      </dd>
+
+      <dt><a href="commify1.sed">Commify numbers 1/3</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>Formats numbers by placing commas before every 3 digits (eg: 1,200,573).</dd>
+
+      <dt><a href="commify2.sed">Commify numbers 2/3</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>A more compact script for versions of sed which recognise Extended RE's.</dd>
+
+      <dt><a href="commify3.sed">Commify numbers 3/3</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Compare with #1. This script expects 100% numeric input.
+        </div>
+      </dd>
+
+      <dt>File polisher (troff)</dt>
+
+      <dd>
+        <div class="last">
+          Very comprehensive suite of filters by Robert Marks which perform a large number
+          of beautifying operations on text files prior to processing by <code>troff</code>. These
+          scripts were used to produce camera-ready output for the <cite>Australian School of
+          Management</cite> between 1985 and 1995. You can download a <a href="polish.tar.gz">gzipped tar archive</a> of the scripts, or individual scripts: <a href="polish0.sed">polish0.sed</a>, <a href="polish1.sed">polish1.sed</a>, <a href="polish2.sed">polish2.sed</a>, <a href="polish3.sed">polish3.sed</a>, <a href="polish4.sed">polish4.sed</a>, <a href="polish5.sed">polish5.sed</a>, <a href="polish6.sed">polish6.sed</a>, <a href="polish7.sed">polish7.sed</a>, <a href="polish8.sed">polish8.sed</a>, <a href="polish9.sed">polish9.sed</a>, or visit <a href="https://web.archive.org/web/20210916192909/http://www.agsm.unsw.edu.au/~bobm/odds+ends/scripts.html">Robert's Web site</a>.
+        </div>
+      </dd>
+
+      <dt><a href="hbanner.sh.txt">Horizontal banner</a> <span class="rating">(<tt>*</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Rotates the vertical output of banner to produce horizontal output. The script assumes a
+          screen size of 80x60. This could be overcome.
+        </div>
+      </dd>
+
+      <dt><a href="untroff.sed">Remove <tt>troff</tt> overstrikes</a>
+      <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          A script to convert <code>troff</code> output to pure text, replacing boldfaces with
+          "<samp>*...*</samp>" and underlines with "<samp>_..._</samp>". Also shows how to justify
+          text using sed.
+        </div>
+      </dd>
+
+      <dt><a href="cat-n.sh.txt">Number lines</a> <span class="rating">(<tt>*</tt>)</span></dt>
+
+      <dd>A short script to display output lines preceded by line numbers. This is similar to the
+      UNIX <code>nl</code> command, or <code>cat -n</code>.</dd>
+
+      <dt><a href="cat-n.sed">Number lines</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          This version demonstrates a technique for manually calculating numbers.
+        </div>
+      </dd>
+
+      <dt><a href="cat-b.sh.txt">Number non-empty lines</a> <span class="rating">(<tt>*</tt>)</span></dt>
+
+      <dd>A short script to display output lines, preceding non-empty lines with a line number.
+      Empty lines affect the count. This is not the same as <code>cat -bn</code>, which does not count
+      empty lines.</dd>
+
+      <dt><a href="cat-b.sed">Number non-empty lines</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          This version demonstrates a technique for manually calculating numbers; it emulates
+          <code>cat -bn</code> exactly.
+        </div>
+      </dd>
+    </dl>
+
+    <h3 id="tabu">Information extraction / tabulation</h3>
+
+    <dl>
+      <dt><a href="subwords.sed">Find subwords</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Search for dictionary words in a string.
+        </div>
+      </dd>
+
+      <dt><a href="cgrep.sh.txt">Extract regular expressions and print the
+      context</a> - by <a href="https://web.archive.org/web/20210916192909/mailto:gsu@nsa.gov">Greg Ubben</a> <span class="rating">(<tt>****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Extract from a file the lines that contain a regular expression, printing the lines
+          containing the pattern and those that surround them.
+        </div>
+      </dd>
+
+      <dt><a href="fullgrep.sh.txt">Extract regular expressions and print the
+      context</a> - thanks to <a href="https://web.archive.org/web/20210916192909/mailto:hartmut.schaefer@zkb.ch">Hartmut Schaefer</a> <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Print all the occurrences of a regular expression in a file.  Each occurrence is
+          printed on a separate line, isolated from the non-matching text (for example,
+	  the regex <tt>\&lt;[A-Za-z]*\&gt;</tt> will yield all the words in the file, one per
+	  line.
+        </div>
+      </dd>
+
+      <dt><a href="anagrams.sed">Find anagrams</a> <span class="rating">(<tt>****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Search for anagrams in a list of words (one word per line).
+        </div>
+      </dd>
+
+      <dt><a href="indexer.sed">Indexer</a> <span class="rating">(<tt>****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          This script collates a list of references to produce an index suitable for a book or
+          magazine. <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/indexer.txt">A detailed description of
+          the way it works</a>, along with alternative versions of the script, is available on the
+          <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/">tutorials page</a>. The script was used by the
+          <cite>Cornerstone</cite> magazine to create an index for a book after typesetting.
+        </div>
+      </dd>
+
+      <dt><a href="maketarg.sed">Show <code>make</code> targets</a> <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Extracts targets for a file from a makefile.
+        </div>
+      </dd>
+
+      <dt><a href="sodelnum.sed">Sort/delimit/number a list of names</a>
+      <span class="rating">(<tt>*****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Sort, partition and number a list of names. This script is not exactly the one described
+          on the <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/">tutorials page</a>, but it resembles it very
+          closely. A thorough analysis of the techniques used in this script is given by the author
+          of the original script in <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/lookup_tables.txt">Using
+          lookup tables with s///</a> and <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/lookup_table_counter.txt">A lookup-table counter</a>.
+        </div>
+      </dd>
+
+      <dt><a href="head.sed">Display beginning of file</a> <span class="rating">(<tt>*</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Display first 10 lines of a file. Like <code>head</code>.
+        </div>
+      </dd>
+    </dl>
+
+    <h3 id="misc">Miscellaneous</h3>
+
+    <dl>
+      <dt><a href="dc.sed">Desktop calculator</a> <span class="rating">(<tt>*****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          This script from sed guru <a href="https://web.archive.org/web/20210916192909/mailto:gsu@nsa.gov">Greg Ubben</a> is a full implementation of the Unix desktop
+          calculator <code>dc</code>. dc is an arbitrary precision, multi-base, stacking calculator. Here
+          is <a href="dc_intro.txt">a quick guide to it</a>, which Greg posted to
+          seders, and an <a href="dc_overview.htm">overview of how it works</a>.
+        </div>
+      </dd>
+
+      <dt><a href="add_decs.sed">Add decimals</a> <span class="rating">(<tt>****</tt>)</span></dt>
+
+      <dd>
+        <div>
+          This impressively short script adds a list of decimal numbers. It pulls this off by
+          transforming and concatenating units in each number into an analogue format, where a=1,
+          aa=2, aaa=3, etc, transforming the result back to decimal, and proceeding with the next
+          digit. Usage of <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/lookup_tables.txt">lookup
+          tables</a> permits to do this with only 9 commands, with a 3-command inner loop; to
+          understand the idea better you might want to peek at <a href="add_decs-nolt.sed">an implementation of the same algorithm without lookup
+          tables</a>.
+        </div>
+        <div class="last">
+           Note that this is <em>not</em> the script explained in <a href="https://web.archive.org/web/20210916192909/mailto:gsu@nsa.gov">Greg Ubben</a>'s <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/greg_add.txt">Adding a list of decimal numbers</a> (on the <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/">tutorials page</a>); Greg's script is found directly in the
+          tutorial.
+        </div>
+      </dd>
+
+      <dt><a href="sierpinski1.sed">Sierpinski triangles 1/3</a> <span class="rating">(<tt>***</tt>)</span></dt>
+      <dt><a href="sierpinski2.sed">Sierpinski triangles 2/3</a> <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>
+          These scripts generate Sierpinski's triangle.  Pass them a line made
+          of many underscores and a single X, something like <tt>______X</tt>.
+      </dd>
+
+      <dt><a href="sierpinski3.sed">Sierpinski triangles 3/3, slow and portable</a> <span class="rating">(<tt>***</tt>)</span></dt>
+      <dt><a href="sierpinski4.sed">Sierpinski triangles 3/3, fast and less portable</a> <span class="rating">(<tt>***</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          To get below 10 commands to do the same, I had to find out the
+          real rule behind Sierpinski's triangle (the other two attemps were
+          somewhat empiric).  It turns out that Sierpinski's triangle is
+          actually Wolfram's rule-90 cellular automaton. :-)
+        </div>
+      </dd>
+
+      <dt><a href="incr_num.sed">Increment a number</a> <span class="rating">(<tt>****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Interesting script to increment numbers. This algorithm is the fastest I know of that
+          does not use both buffers.
+        </div>
+      </dd>
+
+      <dt><a href="turing.sed">Turing Machine in sed</a> <span class="rating">(<tt>****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          A totally useless but quite funny script by <a href="https://web.archive.org/web/20210916192909/mailto:ccb@club-internet.fr">Christophe Blaess</a>: a Turing Machine is able to execute
+          any computable task (albeit slowly and painfully)... so <code>sed</code> can perform any computable
+          task!!! Here is a <a href="turing.txt">description</a> of the input file
+          format, including a sample automaton to increment binary numbers.
+        </div>
+      </dd>
+
+      <dt><a href="sokoban.sed"><tt>sed</tt> <i>sokoban</i></a> by
+       <a href="https://web.archive.org/web/20210916192909/mailto:aurelio@conectiva.com.br">Aurelio Marinho Jargas</a>
+       <span class="rating">(<tt>*****</tt>)</span></dt>
+
+      <dd>
+        <div>
+          Yes, this is a full-featured 90-level <i>sokoban</i> game with color and animation!
+          Play with the arrow keys or with the classic <tt>vi</tt> keys <i>hjkl</i>
+          (left, down, up, right).
+        </div>
+      </dd>
+
+      <dt><a href="arkanoid.sed"><tt>sed</tt> <i>arkanoid</i></a> by
+       <a href="https://web.archive.org/web/20210916192909/mailto:aurelio@conectiva.com.br">Aurelio Marinho Jargas</a>
+       <span class="rating">(<tt>*****</tt>)</span></dt>
+
+      <dd>
+        <div>
+          And yet another masterpiece from the author of the <tt>sed</tt> <i>sokoban</i> game.
+        </div>
+        <div class="warning">
+          You might like the shell script <a href="playsed.sh.txt"><tt>playsed</tt></a> which makes the ball move automatically.
+        </div>
+      </dd>
+
+      <dt><a href="tictactoe.sed"><tt>sed</tt> naughts and crosses</a> <span class="rating">(<tt>*****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          And now, here's a naughts and crosses game too.
+        </div>
+      </dd>
+
+      <dt><a href="bf2c.sed">Brainf**k to C compiler</a> <span class="rating">(<tt>**</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          This scripts convert <a href="https://web.archive.org/web/20210916192909/http://www.muppetlabs.com/~breadbox/bf">Brainf**k</a>
+          programming language to C, ready to be compiled to machine code.
+        </div>
+      </dd>
+
+      <dt><a href="cal.sh.txt">Display month calendar</a> <span class="rating">(<tt>*****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Display a simple calendar for the current month, &agrave; la the UNIX command <code>cal</code>.
+          Only <code>date</code> is required, math is done directly in sed.
+        </div>
+      </dd>
+
+      <dt><a href="cal-year.sh.txt">Display year calendar</a> <span class="rating">(<tt>****</tt>)</span></dt>
+
+      <dd>
+        <div class="last">
+          Display a simple calendar for the current year, very roughly based on the above script.
+          This time date computation is done with dc rather than date.
+        </div>
+      </dd>
+    </dl>
+
+    <h3 id="sdeb"><code>sed</code> debuggers</h3>
+
+    <dl>
+      <dt><a href="sd.py.txt">Python sed debugger</a> by <a href="https://web.archive.org/web/20210916192909/mailto:aurelio@conectiva.com.br">Aurelio Marinho Jargas</a></dt>
+
+      <dd>
+        <div>
+          A python script that reads a <code>sed</code> script from a file and generate another sed
+          script, this one with debug commands. So, it's NOT a <code>sed</code> interpreter, it
+          generates <code>sed</code> debug file in <code>sed</code>! You can debug your
+          <code>sed</code> files with your own version of <code>sed</code> (DOS, Linux, HP-UX,
+          ...). The debug file is saved with a <code>.sedd</code> extension.
+        </div>
+        <div class="last">
+          You can also use it as a script beautifier (to insert and standardize spacing)
+          with the <code>--indent</code> option which writes the beautified script on
+          standard output. Also, it can be used as an expert command analizer, with the
+          <code>--tokenize</code> option, that gives all command information you need
+        </div>
+      </dd>
+
+      <dt><a href="sd.ksh.txt">Korn shell debugger</a> by <a href="https://web.archive.org/web/20210916192909/mailto:brian_hiles@rocketmail.com">Brian Hiles</a></dt>
+
+      <dd>
+        <div class="last">
+          This also instruments the debugged <code>sed</code> script. It implements spypoints on
+          conditional and unconditional criteria that can involve lines, regular expressions, or a
+          combination of both. A man page is embedded in the script.  You can also download an
+	  <a href="sd.sh.txt">older version which runs in the Bourne Shell</a>.
+        </div>
+      </dd>
+    </dl>
+
+    <p><span class="update">Updated 17 Nov 2003</span></p>
+    </div>
+  </body>
+</html>
+
+<!--
+     FILE ARCHIVED ON 19:29:09 Sep 16, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 22:36:51 Apr 26, 2023.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 116.405
+  exclusion.robots: 0.087
+  exclusion.robots.policy: 0.077
+  cdx.remote: 0.06
+  esindex: 0.01
+  LoadShardBlock: 66.002 (3)
+  PetaboxLoader3.datanode: 76.825 (4)
+  load_resource: 107.898
+  PetaboxLoader3.resolve: 61.484
+-->

--- a/grabbag/scripts/index.html
+++ b/grabbag/scripts/index.html
@@ -4,19 +4,19 @@
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>Seder's grab bag - scripts</title>
-    <style type="text/css">@import url(/web/20210916192909cs_/http://sed.sourceforge.net/grabbag/seders.css);</style>
+    <style type="text/css">@import url(/grabbag/seders.css);</style>
   </head>
 
   <body>
     <div class="titolo">
       <div class="sezioni">
-      <h1><a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/"><span>seder's</span> grab bag</a></h1>
+      <h1><a href="/grabbag/"><span>seder's</span> grab bag</a></h1>
       <ul>
-        <li><a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/scripts/">scripts</a></li>
-        <li><a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/">tutorials</a></li>
-        <li><a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/seders/">seders</a></li>
-        <li><a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/ssed/">ssed</a></li>
-        <li><a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/links/">links</a></li>
+        <li><a href="/grabbag/scripts/">scripts</a></li>
+        <li><a href="/grabbag/tutorials/">tutorials</a></li>
+        <li><a href="/grabbag/seders/">seders</a></li>
+        <li><a href="/grabbag/ssed/">ssed</a></li>
+        <li><a href="/grabbag/links/">links</a></li>
       </ul>
       </div>
     </div>
@@ -282,7 +282,7 @@
 
       <dd>
         <div class="last">
-          And finally, we capitalise words with <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/lookup_tables.txt">lookup tables.</a>
+          And finally, we capitalise words with <a href="/grabbag/tutorials/lookup_tables.txt">lookup tables.</a>
         </div>
       </dd>
     </dl>
@@ -302,7 +302,7 @@
         <div class="last">
           Another masterpiece by <a href="https://web.archive.org/web/20210916192909/mailto:gsu@nsa.gov">Greg Ubben</a>. The link above works with all sed implementations,
           while <a href="expand-new.sed">this version</a> only works with GNU sed
-          3.02.80 or <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/ssed/">ssed</a>, but is more readable because it does
+          3.02.80 or <a href="/grabbag/ssed/">ssed</a>, but is more readable because it does
           not contain control characters.
         </div>
       </dd>
@@ -540,9 +540,9 @@
       <dd>
         <div class="last">
           This script collates a list of references to produce an index suitable for a book or
-          magazine. <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/indexer.txt">A detailed description of
+          magazine. <a href="/grabbag/tutorials/indexer.txt">A detailed description of
           the way it works</a>, along with alternative versions of the script, is available on the
-          <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/">tutorials page</a>. The script was used by the
+          <a href="/grabbag/tutorials/">tutorials page</a>. The script was used by the
           <cite>Cornerstone</cite> magazine to create an index for a book after typesetting.
         </div>
       </dd>
@@ -561,10 +561,10 @@
       <dd>
         <div class="last">
           Sort, partition and number a list of names. This script is not exactly the one described
-          on the <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/">tutorials page</a>, but it resembles it very
+          on the <a href="/grabbag/tutorials/">tutorials page</a>, but it resembles it very
           closely. A thorough analysis of the techniques used in this script is given by the author
-          of the original script in <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/lookup_tables.txt">Using
-          lookup tables with s///</a> and <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/lookup_table_counter.txt">A lookup-table counter</a>.
+          of the original script in <a href="/grabbag/tutorials/lookup_tables.txt">Using
+          lookup tables with s///</a> and <a href="/grabbag/tutorials/lookup_table_counter.txt">A lookup-table counter</a>.
         </div>
       </dd>
 
@@ -598,13 +598,13 @@
           This impressively short script adds a list of decimal numbers. It pulls this off by
           transforming and concatenating units in each number into an analogue format, where a=1,
           aa=2, aaa=3, etc, transforming the result back to decimal, and proceeding with the next
-          digit. Usage of <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/lookup_tables.txt">lookup
+          digit. Usage of <a href="/grabbag/tutorials/lookup_tables.txt">lookup
           tables</a> permits to do this with only 9 commands, with a 3-command inner loop; to
           understand the idea better you might want to peek at <a href="add_decs-nolt.sed">an implementation of the same algorithm without lookup
           tables</a>.
         </div>
         <div class="last">
-           Note that this is <em>not</em> the script explained in <a href="https://web.archive.org/web/20210916192909/mailto:gsu@nsa.gov">Greg Ubben</a>'s <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/greg_add.txt">Adding a list of decimal numbers</a> (on the <a href="/web/20210916192909/http://sed.sourceforge.net/grabbag/tutorials/">tutorials page</a>); Greg's script is found directly in the
+           Note that this is <em>not</em> the script explained in <a href="https://web.archive.org/web/20210916192909/mailto:gsu@nsa.gov">Greg Ubben</a>'s <a href="/grabbag/tutorials/greg_add.txt">Adding a list of decimal numbers</a> (on the <a href="/grabbag/tutorials/">tutorials page</a>); Greg's script is found directly in the
           tutorial.
         </div>
       </dd>

--- a/grabbag/seders/index.html
+++ b/grabbag/seders/index.html
@@ -28,13 +28,13 @@
     <h2>seders</h2>
 
     <p><br>
-     <i>seders</i> was created in July '96 by <a href="https://web.archive.org/web/20220823200955/mailto:af137@freenet.toronto.on.ca">Al
+     <i>seders</i> was created in July '96 by <a href="mailto:af137@freenet.toronto.on.ca">Al
     Aab</a> to discuss sed and promote its use. It has grown from a handful of messages per week to
     an active, mature and well-attended list now.</p>
 
-     <p>It is currently hosted by a <a href="https://web.archive.org/web/20220823200955/http://groups.yahoo.com/">Yahoo! Groups</a> server.&nbsp; Its
+     <p>It is currently hosted by a <a href="http://groups.yahoo.com/">Yahoo! Groups</a> server.&nbsp; Its
     home page is at
-     <a href="https://web.archive.org/web/20220823200955/http://groups.yahoo.com/group/sed-users/">http://groups.yahoo.com/group/sed-users/</a>;
+     <a href="http://groups.yahoo.com/group/sed-users/">http://groups.yahoo.com/group/sed-users/</a>;
      go there to register.<br>
      &nbsp;</p>
     </div>

--- a/grabbag/seders/index.html
+++ b/grabbag/seders/index.html
@@ -1,15 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html lang="en">
-  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
-<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
-<script type="text/javascript">
-  __wm.init("https://web.archive.org/web");
-  __wm.wombat("http://sed.sourceforge.net/grabbag/seders/","20220823200955","https://web.archive.org/","web","/_static/",
-	      "1661285395");
-</script>
-<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
-<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
-<!-- End Wayback Rewrite JS Include -->
+  <head>
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>Seder's grab bag - Seders</title>
@@ -49,24 +40,3 @@
     </div>
   </body>
 </html>
-
-<!--
-     FILE ARCHIVED ON 20:09:55 Aug 23, 2022 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 22:36:59 Apr 26, 2023.
-     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
-
-     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
-     SECTION 108(a)(3)).
--->
-<!--
-playback timings (ms):
-  captures_list: 123.008
-  exclusion.robots: 0.063
-  exclusion.robots.policy: 0.055
-  cdx.remote: 0.085
-  esindex: 0.008
-  LoadShardBlock: 49.842 (3)
-  PetaboxLoader3.datanode: 59.498 (4)
-  load_resource: 193.404
-  PetaboxLoader3.resolve: 122.695
--->

--- a/grabbag/seders/index.html
+++ b/grabbag/seders/index.html
@@ -4,19 +4,19 @@
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>Seder's grab bag - Seders</title>
-    <style type="text/css">@import url(/web/20220823200955cs_/http://sed.sourceforge.net/grabbag/seders.css);</style>
+    <style type="text/css">@import url(/grabbag/seders.css);</style>
   </head>
 
   <body>
     <div class="titolo">
       <div class="sezioni">
-      <h1><a href="/web/20220823200955/http://sed.sourceforge.net/grabbag/"><span>seder's</span> grab bag</a></h1>
+      <h1><a href="/grabbag/"><span>seder's</span> grab bag</a></h1>
       <ul>
-        <li><a href="/web/20220823200955/http://sed.sourceforge.net/grabbag/scripts/">scripts</a></li>
-        <li><a href="/web/20220823200955/http://sed.sourceforge.net/grabbag/tutorials/">tutorials</a></li>
-        <li><a href="/web/20220823200955/http://sed.sourceforge.net/grabbag/seders/">seders</a></li>
-        <li><a href="/web/20220823200955/http://sed.sourceforge.net/grabbag/ssed/">ssed</a></li>
-        <li><a href="/web/20220823200955/http://sed.sourceforge.net/grabbag/links/">links</a></li>
+        <li><a href="/grabbag/scripts/">scripts</a></li>
+        <li><a href="/grabbag/tutorials/">tutorials</a></li>
+        <li><a href="/grabbag/seders/">seders</a></li>
+        <li><a href="/grabbag/ssed/">ssed</a></li>
+        <li><a href="/grabbag/links/">links</a></li>
       </ul>
       </div>
     </div>

--- a/grabbag/seders/index.html
+++ b/grabbag/seders/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("http://sed.sourceforge.net/grabbag/seders/","20220823200955","https://web.archive.org/","web","/_static/",
+	      "1661285395");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
+    <title>Seder's grab bag - Seders</title>
+    <style type="text/css">@import url(/web/20220823200955cs_/http://sed.sourceforge.net/grabbag/seders.css);</style>
+  </head>
+
+  <body>
+    <div class="titolo">
+      <div class="sezioni">
+      <h1><a href="/web/20220823200955/http://sed.sourceforge.net/grabbag/"><span>seder's</span> grab bag</a></h1>
+      <ul>
+        <li><a href="/web/20220823200955/http://sed.sourceforge.net/grabbag/scripts/">scripts</a></li>
+        <li><a href="/web/20220823200955/http://sed.sourceforge.net/grabbag/tutorials/">tutorials</a></li>
+        <li><a href="/web/20220823200955/http://sed.sourceforge.net/grabbag/seders/">seders</a></li>
+        <li><a href="/web/20220823200955/http://sed.sourceforge.net/grabbag/ssed/">ssed</a></li>
+        <li><a href="/web/20220823200955/http://sed.sourceforge.net/grabbag/links/">links</a></li>
+      </ul>
+      </div>
+    </div>
+
+    <div class="menu">
+    </div>
+
+    <div class="testo">
+    <h2>seders</h2>
+
+    <p><br>
+     <i>seders</i> was created in July '96 by <a href="https://web.archive.org/web/20220823200955/mailto:af137@freenet.toronto.on.ca">Al
+    Aab</a> to discuss sed and promote its use. It has grown from a handful of messages per week to
+    an active, mature and well-attended list now.</p>
+
+     <p>It is currently hosted by a <a href="https://web.archive.org/web/20220823200955/http://groups.yahoo.com/">Yahoo! Groups</a> server.&nbsp; Its
+    home page is at
+     <a href="https://web.archive.org/web/20220823200955/http://groups.yahoo.com/group/sed-users/">http://groups.yahoo.com/group/sed-users/</a>;
+     go there to register.<br>
+     &nbsp;</p>
+    </div>
+  </body>
+</html>
+
+<!--
+     FILE ARCHIVED ON 20:09:55 Aug 23, 2022 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 22:36:59 Apr 26, 2023.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 123.008
+  exclusion.robots: 0.063
+  exclusion.robots.policy: 0.055
+  cdx.remote: 0.085
+  esindex: 0.008
+  LoadShardBlock: 49.842 (3)
+  PetaboxLoader3.datanode: 59.498 (4)
+  load_resource: 193.404
+  PetaboxLoader3.resolve: 122.695
+-->

--- a/grabbag/ssed/index.html
+++ b/grabbag/ssed/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("http://sed.sourceforge.net/grabbag/ssed/","20211026164307","https://web.archive.org/","web","/_static/",
+	      "1635266587");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
+    <title>Seder's grab bag - super sed</title>
+    <style type="text/css">@import url(/web/20211026164307cs_/http://sed.sourceforge.net/grabbag/seders.css);;</style>
+  </head>
+
+  <body>
+    <div class="titolo">
+      <div class="sezioni">
+      <h1><a href="/web/20211026164307/http://sed.sourceforge.net/grabbag/"><span>seder's</span> grab bag</a></h1>
+      <ul>
+        <li><a href="/web/20211026164307/http://sed.sourceforge.net/grabbag/scripts/">scripts</a></li>
+        <li><a href="/web/20211026164307/http://sed.sourceforge.net/grabbag/tutorials/">tutorials</a></li>
+        <li><a href="/web/20211026164307/http://sed.sourceforge.net/grabbag/seders/">seders</a></li>
+        <li><a href="/web/20211026164307/http://sed.sourceforge.net/grabbag/ssed/">ssed</a></li>
+        <li><a href="/web/20211026164307/http://sed.sourceforge.net/grabbag/links/">links</a></li>
+      </ul>
+      </div>
+    </div>
+
+    <div class="menu"></div>
+
+    <div class="testo">
+    <h2>super sed</h2>
+
+    <h3>my own enhanced version of sed</h3>
+
+    <p>Super-sed is a heavily enhanced version of <tt>sed</tt> that I
+    wrote. The current version is 3.62.  The win32 executable has been
+    kindly provided by Laurent Vogel; it does not require any support
+    library. You can download it from here as:</p>
+
+    <ul>
+      <li><a href="sed-3.62.tar.gz">Source code in .tar.gz format</a> (835k)</li>
+      <li><a href="sed-3.62.zip">Binary Win32 executable, zipped</a> (43k)</li>
+    </ul>
+
+    <p><span class="update">Updated 11 Feb 2005</span></p>
+    </div>
+  </body>
+</html>
+
+<!--
+     FILE ARCHIVED ON 16:43:07 Oct 26, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 22:37:00 Apr 26, 2023.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 69.667
+  exclusion.robots: 0.07
+  exclusion.robots.policy: 0.06
+  cdx.remote: 0.057
+  esindex: 0.009
+  LoadShardBlock: 47.103 (3)
+  PetaboxLoader3.datanode: 79.459 (4)
+  load_resource: 151.211
+  PetaboxLoader3.resolve: 49.73
+-->

--- a/grabbag/ssed/index.html
+++ b/grabbag/ssed/index.html
@@ -4,19 +4,19 @@
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>Seder's grab bag - super sed</title>
-    <style type="text/css">@import url(/web/20211026164307cs_/http://sed.sourceforge.net/grabbag/seders.css);;</style>
+    <style type="text/css">@import url(/grabbag/seders.css);;</style>
   </head>
 
   <body>
     <div class="titolo">
       <div class="sezioni">
-      <h1><a href="/web/20211026164307/http://sed.sourceforge.net/grabbag/"><span>seder's</span> grab bag</a></h1>
+      <h1><a href="/grabbag/"><span>seder's</span> grab bag</a></h1>
       <ul>
-        <li><a href="/web/20211026164307/http://sed.sourceforge.net/grabbag/scripts/">scripts</a></li>
-        <li><a href="/web/20211026164307/http://sed.sourceforge.net/grabbag/tutorials/">tutorials</a></li>
-        <li><a href="/web/20211026164307/http://sed.sourceforge.net/grabbag/seders/">seders</a></li>
-        <li><a href="/web/20211026164307/http://sed.sourceforge.net/grabbag/ssed/">ssed</a></li>
-        <li><a href="/web/20211026164307/http://sed.sourceforge.net/grabbag/links/">links</a></li>
+        <li><a href="/grabbag/scripts/">scripts</a></li>
+        <li><a href="/grabbag/tutorials/">tutorials</a></li>
+        <li><a href="/grabbag/seders/">seders</a></li>
+        <li><a href="/grabbag/ssed/">ssed</a></li>
+        <li><a href="/grabbag/links/">links</a></li>
       </ul>
       </div>
     </div>

--- a/grabbag/ssed/index.html
+++ b/grabbag/ssed/index.html
@@ -1,15 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html lang="en">
-  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
-<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
-<script type="text/javascript">
-  __wm.init("https://web.archive.org/web");
-  __wm.wombat("http://sed.sourceforge.net/grabbag/ssed/","20211026164307","https://web.archive.org/","web","/_static/",
-	      "1635266587");
-</script>
-<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
-<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
-<!-- End Wayback Rewrite JS Include -->
+  <head>
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>Seder's grab bag - super sed</title>
@@ -51,24 +42,3 @@
     </div>
   </body>
 </html>
-
-<!--
-     FILE ARCHIVED ON 16:43:07 Oct 26, 2021 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 22:37:00 Apr 26, 2023.
-     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
-
-     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
-     SECTION 108(a)(3)).
--->
-<!--
-playback timings (ms):
-  captures_list: 69.667
-  exclusion.robots: 0.07
-  exclusion.robots.policy: 0.06
-  cdx.remote: 0.057
-  esindex: 0.009
-  LoadShardBlock: 47.103 (3)
-  PetaboxLoader3.datanode: 79.459 (4)
-  load_resource: 151.211
-  PetaboxLoader3.resolve: 49.73
--->

--- a/grabbag/tutorials/custom_sed.htm
+++ b/grabbag/tutorials/custom_sed.htm
@@ -1,0 +1,479 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("http://sed.sourceforge.net/grabbag/tutorials/custom_sed.htm","20211006103814","https://web.archive.org/","web","/_static/",
+	      "1633516694");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
+    <title>Custom sed Proposal</title>
+    <meta name="GENERATOR" content="Mozilla/3.0Gold (Win95; I) [Netscape]">
+  </head>
+
+  <body>
+<pre>
+  
+  name:     $RCSfile: custom_sed.spec,v $
+  process:  Outline of the proposed custom sed, to be based on the existing 
+            GNU sed 2.05
+  author:   Simon Taylor
+  revision: $Id: custom_sed.spec,v 1.2 1998/05/01 11:27:29 simon Exp simon $
+-------------------------------------------------------------------------------
+
+  <b>1.0 Overview
+
+</b>      1.1 General 
+      
+          From the outset our main aim should be to produce a custom sed 
+          for our own purposes that is always capable of running existing 
+          sed scripts portably and efficiently. 
+
+          The custom sed will be freely available in source form to anyone 
+          who wants it, subject to the terms of the typical GNU GPL 
+          (General Public License).
+
+          Changes should be to enhance the sort of program sed already is, 
+          (ie: small, fast and powerful), and not to turn it into an awk 
+          or a perl.
+
+      1.2 Portability
+
+          The changes should be portable to all contemporary Unixes and if 
+          the underlying GNU code permits, to the DOS/Windows environments.
+
+      1.3 How the document is structured
+      
+          The proposed changes are broken up into two groups. The first of
+          these groups, section 2.0, covers items that have been requested
+          by a number of seders, and which seem likely to be implemented
+          in a realistic timeframe. The second group, covered in section 3.0,
+          is a list of the balance of items that may be addressed at a later
+          date. Section 4 covers testing.
+      
+ <b>2.0 Implementation Wish List - To do now
+</b>  
+      2.01 'r' command, read file into pattern space
+
+           (Al Aab)
+           A form of r (super r ?), to get a file into the pattern 
+           space (or the hold space).  As is, r is 1 of the least 
+           used/useful sed commands, but if you could implement a 
+           super-r then you could merge several input files.
+
+           (Greg Ubben)
+           I think it was suggested to have the r command read into the 
+           pattern space where the text can be manipulated.  Rather than this 
+           (slurping a whole file into the pattern space), maybe add an f 
+           (file) or e (edit) command that will essentially switch the 
+           input stream to the named file.  Then you can process each line 
+           separately.  Might push this file (like .so in nroff), returning 
+           to the original stream when the end is reached.
+           This one needs to be thought out a lot more -- I just thought of it.
+
+      2.02 Case insensitivity
+
+           (Al Aab and others)
+           An new 'i' flag to the s command and on the command line
+
+           s/RE/replacement/i    # meaning match RE regardless of case.
+           /match/i              # as above
+           sed -i ...            # meaning everything should be 
+                                 # case-insensitive till the next -e
+
+      2.03 Debugger
+
+           2.03.01 -d0 print parameters and exit
+           
+                   (Doug McClure)
+                   An option to print the parameters passed to sed.
+                   This would help debug scripts that are mangled by the 
+                   shell process. The -d0 flag would output the parameters
+                   passed to sed and then exit.
+
+           2.03.02 -d1 print a trace of sed commands encountered
+          
+                   (Simon Taylor)
+                   An option to output a simple indicator of each sed command
+                   (and flags) processed by sed. For instance, the processing
+                   of sed 's/abc/def/g' would result in the debugging output:
+                   
+                   Command: s  Flag(s): g
+                   
+                   being output on the stderr stream.
+                   
+          2.03.03  Print better error messages. 
+          
+                   (Doug McClure)
+                   sed often complains about extra garbage, but it would be
+                   helpful if it would print where it detected the garbage as 
+                   it began parsing. 
+
+                   (Simon Taylor)
+                   The error messages output by the GNU gawk program are an
+                   outstanding example of how user-friendly error recovery can
+                   be. However, this is often not a trivial programming task.
+
+      2.04 Extending the 'y' command (y/a-z/A-Z/)
+
+           (Greg Ubben/Al Aab))
+           Modify the 'y' to enable character ranges 
+          
+                  y/a-z/A-Z/
+
+      2.05 White space = space/s, tab/s, nl/s
+
+           (Al Aab)
+           Suggest "\s" to mean any of \t, space, \r, \f or \n
+          
+      2.06 Use of \n and \t
+
+           (Al Aab and others)
+           Enhance sed to accept \n and \t in the replacement part of a 
+           s/... /.../
+
+           (See 2.09 also)
+
+      2.07 New command-line switches:
+
+           (Eric Pement)
+           --traditional
+           --compat
+            -c   Compatibility mode. Disables new features to permit 
+                 compatible operation with traditional sed syntax.
+           
+            -E   Within regular expressions ONLY, support for Extended regexps
+                 (like egrep), so that braces {..} and parens (..) do not need
+                 to be preceded by the backslash as normally. Extended regexp
+                 syntax should be consisted with GNU grep.
+
+            -H   If hold space is empty, do not append leading newline to hold
+                 space when using the H command.
+
+           --help
+           --usage
+            -h
+                 Brief message explaining syntax of sed commands and switches.
+
+      2.08 New regexp operators:
+
+           (Eric Pement)
+           +  one or more of the previous atom. Equivalent to  \{1,\}
+           ?  zero or one of the previous atom. Equivalent to  \{0,\1}
+
+           with Perl-style minimal pattern matching:
+           *?   minimal match of *
+           +?   minimal match of +
+           ??   minimal match of ?
+
+            |   matches the regexp on either side of the bar
+
+           \(...\)  - in standard GNU sed, or
+            (...)   - with the -E switch
+                 should support grouping as well as backreferences.
+                 I.e., sed -E "/foo(bar){5}/d"  should be valid syntax
+                 to delete lines matching "foobarbarbarbarbar".
+          
+      2.09 New regexp metacharacters:
+
+           (Eric Pement)
+           \\   - literal backslash
+           \a   - alert (^G)
+           \e   - escape
+           \f   - formfeed
+           \r   - carriage return
+           \t   - tab
+           \v   - vertical tab
+           \xhh - the ASCII character corresponding to 2 hex digits hh.
+           \ooo - the ASCII character corresponding to 3 octal digits ooo
+           |    - match the regexp on either side of the vertical bar
+        
+           Regexp metacharacters should be usable in pattern matching
+           (/match/) and in the LHS and RHS of a substitution (s/LHS/RHS/)!
+           Especially, GNU sed should support hex and octal notation.
+
+      2.10 New sed commands:
+
+           (Eric Pement)
+           ~    Print current line number without a trailing newline
+
+           E    Erase first line of pattern space (like D), but return to loop
+                at top of the current brace level instead of at top of script
+
+         q NUM  Optional numeric argument, NUM, sets exit code when quitting
+                E.g, 'q5' or 'q 5' exits script with errorlevel 5
+
+         Q NUM  Quit applying sed script to input file, but continue printing
+                the rest of the file to stdout (unless -n is used). Accepts an
+                optional numeric argument, NUM, to set exit code.
+
+         v NUM  Requires GNU sed version NUM or higher to run. If NUM is
+                omitted, requires GNU sed to run (if run on normal seds, 'v'
+                will generate an error anyway).
+
+           z    Zero out hold space. Same as "{x;s/.*//;x}"
+
+      2.11 Other wishes (features already in HHsed):
+
+           (Eric Pement)
+           * a, c and i commands don't insist on a leading backslash '\n' in 
+             the text.
+
+           * r and w commands do not insist on whitespace before the filename.
+
+           * The g, P, p and 'n' options on s commands may be given in any 
+             order.
+
+             On the s command, an option P is allowed: Print the first line of 
+             the current text buffer if a replacement was made.
+
+           * Escape sequences are valid in all contexts except file names and
+             labels.
+
+           * The full range of characters are allowed all 256 values.
+          
+           * The W command (write first line of pattern space to file).
+
+           W [wfile]   Write the first line of the current text buffer to 
+                       'wfile'. If no 'wfile' is given standard output is used.
+
+           * The T command (branch on last substitution failed).
+          
+           T [label]   Branch to the ':' command with the given 'label' if no s 
+                       commands have succeeded since the last input line or t 
+                       or T command. Branch to the end of the script if no 
+                       'label' is given.
+          
+           * The second address [of a range address] may be in the form of 
+             '+number'. This means that the command will stay selected for 
+             number lines after the first address is satisfied.
+          
+           * The empty RE "//" is allowed as a first address if a previous RE 
+             has been compiled.
+          
+      2.12 Several pattern/hold spaces
+
+           With attendant commands to use those spaces/buffers
+
+           (Greg Ubben)
+           Allow h/H/g/G/x commands to be followed by a single digit to allow 
+           up to 10 named buffers (besides the normal hold space).  Sure you 
+           could allow more, but allowing arbitrary names like awk/Perl 
+           variables gets out of the spirit of sed.  
+
+           or, as a variation,
+
+           (Al Aab)
+           a stack of pattern/spaces
+           with commands:
+            push
+            pop
+            swap
+
+      2.13 Allow addresses to specify file 'n' of a multiple file input
+           stream.
+           
+           (Greg Ubben)
+           A feature which I suggested years ago to the GNU sed maintainer
+           would overcome a sed limitation when processing multiple files.  
+           Currently sed has no way of telling where one file ends and 
+           another starts.  It just looks like one long stream of text.  
+           So you can't write a script to extract the Subject: header 
+           out of a series of news articles, for instance, because it 
+           wouldn't know if it was in the body of an article or the header 
+           of the next.  I think the syntax I suggested involved using a 
+           period in line number addressing to denote a line number relative 
+           to the current file rather than to the entire stream.  So:
+
+               5        line 5 of entire stream (occurs no more than once)
+               .5       5th line of each file
+               $        end of entire stream (occurs exactly once)
+               .$       last line of current file
+               .1,/^$/  extract headers of a series of messages
+               
+           I also suggested a number followed by a period to denote a file 
+           number, so:
+               
+               3.18     means the 18th line of the 3rd file
+               3.$      last line of 3rd file
+               3.       could be short for 3.1,3.$ when used as only address, or
+                        3.1 when used as address1, or 3.$ when used as address2
+                        Or could be considered illegal syntax.
+               $.18     18th line of last file
+               2.13,5.3 from file 2, line 13 to file 5, line 3
+               
+           This should be easy to implement and seems to fit into the spirit 
+           of sed.
+               
+      2.14 Determining r and w file names at run time
+
+           (Greg Ubben and others)
+           Another common thing you have to use awk/Perl for, is writing 
+           files whose names are determined at run-time from the contents 
+           of the input.  Such as splitting C functions in one big program 
+           out into separate .c files named for each function.  Just can't 
+           be done in sed.  One way to implement this would be to have an RE 
+           syntax that remembers the text as the filename to use (e.g., 
+           \(\(...\)\), though that's pretty ugly), which could occur in a 
+           /pattern/ address or in a s/// command, and if you use a w 
+           command without a filename given, it uses the last text matched 
+           by this RE syntax as the filename.  For consistency, r command 
+           should allow this too, though not real useful there.
+
+           The r/w commands would be dynamic in this case -- opening/closing 
+           at runtime rather than staying open as it works now.  So you 
+           could write 1000 lines at the beginning of a file, and read them 
+           back later in the file.  If no previous RE has set the filename, 
+           might default it to a temporary scratch filename.
+
+      2.15 A BEGIN address
+
+           Add the ability to specify a sed action at the position in the 
+           stream before the first line is read. ie:
+
+           0{ blah; blah; }
+           
+      2.16 Enhanced y command
+
+           (Greg Ubben)
+           Add a Y command, in the spirit of P and D, that works like 
+           y///, except it only transforms up to the first newline.
+           Allows you to move text to be transformed up to the front to 
+           transform only part of a line, rather than having to move 
+           stuff you don't want changed out to the hold space like we do 
+           now.  May not be useful enough to warrant adding it -- just 
+           an idea.  Could do same thing with S///g command.  Actually, 
+           what we *really* need are allowing \u, \U, \l, \L etc. on the 
+           RHS of a s/// for changing case -- then you can leave the
+           y/// command as it is.
+
+  <b>3.0 Implementation Wish List - To consider later
+
+</b>      3.01 Ability to split files into several, f0000, f0001, ... , fnnnn
+
+           sed     -o "anyheader" myfile
+           should chop myfile into subfiles myfile.000, myfile.001, ...
+           each subfile has line 1 staring with the substring "anyheader"
+ 
+      3.02 Near search/replace
+
+           Al suggests:
+           
+           "RE1 and RE2, if they are within n lines of each other, a la 
+           Boolean near of altavista power search"
+
+           Comments anyone?
+
+      3.03 Paragraph processing
+
+           Various suggestions to enable sed to support different kinds of
+           record separators.
+
+      3.04 String back-reference, dynamically
+
+           Extending the back-reference \1,\2, ... ,\9
+
+           * NEED INPUT *
+
+      3.05 The ability to deal with the null character (hex/octal/decimal zero).
+
+           Extend sed so that is can read input that includes (and is
+           not terminated by) the null character. Other suggestions to
+           extend sed to operate against true binary data.
+
+      3.06 Self-modification
+
+           * NEED INPUT *
+
+      3.07 Nor, nand, exclusive or
+
+           * NEED INPUT *
+
+  <b>4.0 Testing
+
+</b>      It is vital that we start with a set of test scripts that broadly 
+      define the agreed behavior of the notional 'standard' sed.
+
+      Each of the sed commands should be represented by one or more test
+      scripts and a corresponding results file. ie: for the 'p' command, we
+      might have a test case as simple as:
+
+      sed '3,6p' some_file
+
+      And a test result file that contains the expected output.
+
+      This is a trivial example, but for regression testing it is vital 
+      that we can run each iteration of the custom sed through as large
+      a set of automated tests as possible.
+
+      The sed one liners might be a good place to start. 
+
+      I already have a mechanism to run the tests, all we need is the 
+      group to supply test cases and results that we all agree are 
+      'standard'.
+
+ <b>5.0 Distribution
+
+</b>      Initially via the seders mailing list and associated WWW sites.
+
+ <b>6.0 Input
+
+</b>      This specification is based on ideas submitted by members of the
+      seders mailing list, particularly the following, (more submissions 
+      are always welcome).
+
+      Al Aab
+      Edgar Allen
+      Otavio Exel
+      Brendan Macmillan
+      Dennis Marti
+      Doug McClure
+      Eric Pement
+      Greg Ubben
+
+------------------------------------------------------------------------------
+$Log: custom_sed.spec,v $
+Revision 1.2  1998/05/01 11:27:29  simon
+Created section 2 for items more likely to be implemented in
+the near future, and section 3 for those to be considered
+later.  Expanded on "r" command changes, added paragraphs for
+multiple pattern and hold spaces, distinguishing multiple files on
+input, dynamically determining file names for the "r" and "w"
+commands, a proposed BEGIN address and an enhanced "y" command.
+Also attempted to attribute the authors of suggestions where possible.
+
+Revision 1.1  1998/04/22 12:12:36  simon
+Modified description of 'r' wish list item, also added
+new item re multiple pattern/hold spaces.
+
+Revision 1.0  1998/04/21 12:19:27  simon
+Initial revision
+</pre>
+  </body>
+</html>
+
+<!--
+     FILE ARCHIVED ON 10:38:14 Oct 06, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 22:45:04 Apr 26, 2023.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 277.957
+  exclusion.robots: 0.119
+  exclusion.robots.policy: 0.107
+  cdx.remote: 0.084
+  esindex: 0.012
+  LoadShardBlock: 222.017 (3)
+  PetaboxLoader3.datanode: 237.48 (4)
+  load_resource: 59.606
+  PetaboxLoader3.resolve: 24.21
+-->

--- a/grabbag/tutorials/custom_sed.htm
+++ b/grabbag/tutorials/custom_sed.htm
@@ -1,15 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html lang="en">
-  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
-<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
-<script type="text/javascript">
-  __wm.init("https://web.archive.org/web");
-  __wm.wombat("http://sed.sourceforge.net/grabbag/tutorials/custom_sed.htm","20211006103814","https://web.archive.org/","web","/_static/",
-	      "1633516694");
-</script>
-<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
-<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
-<!-- End Wayback Rewrite JS Include -->
+  <head>
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>Custom sed Proposal</title>
@@ -456,24 +447,3 @@ Initial revision
 </pre>
   </body>
 </html>
-
-<!--
-     FILE ARCHIVED ON 10:38:14 Oct 06, 2021 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 22:45:04 Apr 26, 2023.
-     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
-
-     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
-     SECTION 108(a)(3)).
--->
-<!--
-playback timings (ms):
-  captures_list: 277.957
-  exclusion.robots: 0.119
-  exclusion.robots.policy: 0.107
-  cdx.remote: 0.084
-  esindex: 0.012
-  LoadShardBlock: 222.017 (3)
-  PetaboxLoader3.datanode: 237.48 (4)
-  load_resource: 59.606
-  PetaboxLoader3.resolve: 24.21
--->

--- a/grabbag/tutorials/hanoi.htm
+++ b/grabbag/tutorials/hanoi.htm
@@ -171,7 +171,7 @@ Done!<br>
 </pre>
 
     <address>
-      <a href="https://web.archive.org/web/20220202075603/http://www.notelrac.com/">Carl Hommel</a>, <a href="https://web.archive.org/web/20220202075603/mailto:notelrac@notelrac.com">notelrac@notelrac.com</a>
+      <a href="http://www.notelrac.com/">Carl Hommel</a>, <a href="mailto:notelrac@notelrac.com">notelrac@notelrac.com</a>
     </address>
   </body>
 </html>

--- a/grabbag/tutorials/hanoi.htm
+++ b/grabbag/tutorials/hanoi.htm
@@ -1,15 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html lang="en">
-  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
-<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
-<script type="text/javascript">
-  __wm.init("https://web.archive.org/web");
-  __wm.wombat("http://sed.sourceforge.net/grabbag/tutorials/hanoi.htm","20220202075603","https://web.archive.org/","web","/_static/",
-	      "1643788563");
-</script>
-<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
-<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
-<!-- End Wayback Rewrite JS Include -->
+  <head>
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>sed can do Towers of Hanoi</title>
@@ -184,24 +175,3 @@ Done!<br>
     </address>
   </body>
 </html>
-
-<!--
-     FILE ARCHIVED ON 07:56:03 Feb 02, 2022 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 22:45:02 Apr 26, 2023.
-     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
-
-     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
-     SECTION 108(a)(3)).
--->
-<!--
-playback timings (ms):
-  captures_list: 95.596
-  exclusion.robots: 0.082
-  exclusion.robots.policy: 0.069
-  cdx.remote: 0.063
-  esindex: 0.009
-  LoadShardBlock: 66.307 (3)
-  PetaboxLoader3.datanode: 123.366 (5)
-  load_resource: 237.528 (2)
-  PetaboxLoader3.resolve: 90.289 (2)
--->

--- a/grabbag/tutorials/hanoi.htm
+++ b/grabbag/tutorials/hanoi.htm
@@ -1,0 +1,207 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("http://sed.sourceforge.net/grabbag/tutorials/hanoi.htm","20220202075603","https://web.archive.org/","web","/_static/",
+	      "1643788563");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
+    <title>sed can do Towers of Hanoi</title>
+    <link rev="made" href="mailto:notelrac@notelrac.com">
+  </head>
+
+  <body bgcolor="#ffffff">
+    <h1>sed can do Towers of Hanoi</h1>
+<pre>
+Article 3064 of net.unix: 
+ion: <b>version B 2.10.2 9/18/84; site masscomp.UUCP</b>
+From: <b><i>gbergman@ucbtopaz.CC.Berkeley.ARPA</i></b>
+Newsgroups: <b>net.unix</b>
+Subject: <b>sed can do Towers of Hanoi</b>
+Date: <b>21 Nov 84 04:20:04 GMT</b>
+Organization: <b>Univ. of Calif., Berkeley CA USA</b>
+
+<br>
+
+If you put the 60-line sed script near the end of this message
+in a file, e.g. sed.hanoi, and then do
+<br>
+    sed -f sed.hanoi<br>
+and type in, say
+<br>
+    :abcd: : :&lt;CR&gt;&lt;CR&gt;<br>
+(notice-- TWO carriage returns-- a peculiarity of sed), then
+it will output the sequence of states involved in moving 4 rings,
+the largest called "a" and the smallest called "d", from the
+first to the second of three towers, so that the rings on any
+tower at any time are in descending order of size.  You can start with
+a different arrangement and a different number of rings, say
+:ce:b:ax: and it will still give the shortest procedure for
+moving them all to the middle tower.  The rules are: the names
+of the rings must all be lower-case letters, they must be input within
+<b>3</b> fields (representing the towers) delimited by 4 colons, such that
+the letters within each field are in alphabetical order (= rings in
+descending order of size).
+<br>
+For the benefit of anyone who wants to figure out the script,
+I will explain that an "internal" line of the form
+<br>
+    b:0abx:1a2b3 :2   :3x2  <br>
+has the following meaning: the material after the three markers :1 :2
+:3 represents the three towers; in this case the current set-up is
+:ab :   :x  :.  The numbers after a, b and x in these fields indicate
+that the next time it gets a chance, it will move a to tower 2, move b
+to tower 3, and move x to tower 2.  The string after :0 just keeps
+track of the alphabetical order of the names of the rings.  The b at the
+beginning means that it is now dealing with ring  b  (either about to
+move it, or re-evaluating where it should next be moved to).
+<br>
+Although this version is "limited" to 26 rings because of the size
+of the alphabet, one could write a script using the same idea in which
+the rings were represented by arbitrary [strings][within][brackets], and
+in place of the built-in line of the script giving the order of the
+letters of the alphabet, it would accept from the user a line giving the
+ordering to be assumed, e.g. [ucbvax][decvax][hplabs][foo][bar].
+<br>
+While on the subject, I will repeat at the very end of this note
+a much shorter file to do Towers of Hanoi using troff that a friend
+posted for me a year or so ago, before I was on a machine that
+subscribed to the net.  If you put it in a file "troff.hanoi", and
+do  nroff -rr5 troff.hanoi,  it will output instructions for moving 5
+rings from tower 1 to tower 2; generally, just put the desired number
+of rings after the -rr on the command line.  In this case, you don't
+have a choice of initial state, aside from choosing the number of rings.
+<br>
+    Have fun!<br>
+<br>
+    George Bergman<br>
+<br>
+    Math, UC Berkeley 94720 USA<br>
+<br>
+<br>
+    ucbvax!ucbcartan!gbergman (if your mailer can<br>
+<br>
+    digest a 9-letter name; if not maybe:)<br>
+<br>
+    ucbvax!cartan:gbergman  or<br>
+<br>
+    <i>gbergman%cartan@berkeley</i><br>
+<br>
+#----------------------sed.hanoi------------------------------
+# cleaning, diagnostics
+s/  *//g
+/^$/d
+/[^a-z:]/{a\
+Impermissible characters: use only a-z and ":".  Try again.
+d
+}
+/^:[a-z]*:[a-z]*:[a-z]*:$/!{a\
+incorrect format: use\
+\       : string1 : string2 : string3 :&lt;CR&gt;&lt;CR&gt;\
+Try again.
+d
+}
+/\([a-z]\).*\1/{a\
+Repeated letters not allowed.  Try again.
+d
+}
+# initial formatting
+h
+s/[a-z]/ /g
+<b>G</b>
+s/^:\( *\):\( *\):\( *\):\n:\([a-z]*\):\([a-z]*\):\([a-z]*\):$/:1\4\2\3:2\5\1\3:3\6\1\2:0/
+s/[a-z]/&amp;2/g
+s/^/abcdefghijklmnopqrstuvwxyz/
+:a
+s/^\(.\).*\1.*/&amp;\1/
+s/.//
+/^[^:]/ba
+s/\([^0]*\)\(:0.*\)/\2\1:/
+s/^[^0]*0\(.\)/\1&amp;/
+:b
+# outputting current state without markers
+h
+s/.*:1/:/
+s/[123]//gp
+g
+:c
+# establishing destinations
+/^\(.\).*\1:1/td
+/^\(.\).*:1[^:]*\11/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\31/
+/^\(.\).*:1[^:]*\12/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\33/
+/^\(.\).*:1[^:]*\13/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\32/
+/^\(.\).*:2[^:]*\11/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\33/
+/^\(.\).*:2[^:]*\12/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\32/
+/^\(.\).*:2[^:]*\13/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\31/
+/^\(.\).*:3[^:]*\11/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\32/
+/^\(.\).*:3[^:]*\12/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\31/
+/^\(.\).*:3[^:]*\13/s/^\(.\)\(.*\1\([a-z]\).*\)\3./\3\2\33/
+bc
+# iterate back to find smallest out-of-place ring
+:d
+s/^\(.\)\(:0[^:]*\([^:]\)\1.*:\([123]\)[^:]*\1\)\4/\3\2\4/
+td
+# move said ring (right, resp. left)
+s/^\(.\)\(.*\)\1\([23]\)\(.*:\3[^ ]*\) /\1\2 \4\1\3/
+s/^\(.\)\(.*:\([12]\)[^ ]*\) \(.*\)\1\3/\1\2\1\3\4 /
+tb
+s/.*/Done!  Try another, or end with ^D./p
+d
+#------------------end sed.hanoi------------------------------
+<br>
+.\"------------------troff.hanoi----------------------------------
+.de H
+.nr d \\$1-1
+.if \\nd .H \\nd \\$2 \\$4 \\$3
+<br>
+Transfer ring \\$1 from tower \\$2 to tower \\$3.<br>
+.nr d \\$1-1
+.if \\nd .H \\nd \\$4 \\$3 \\$2
+</pre>
+    <hr>
+<pre>
+Initial state:  \nr rings all on tower A; #1 on top.
+.H \nr A B C
+<br>
+Done!<br>
+<br>
+</pre>
+    <hr>
+<pre>
+<font size="2">Usenet/Mail file converted on Thursday, July 20, 1995
+ by by htmlize.pl, version 1.2b3
+</font>
+</pre>
+
+    <address>
+      <a href="https://web.archive.org/web/20220202075603/http://www.notelrac.com/">Carl Hommel</a>, <a href="https://web.archive.org/web/20220202075603/mailto:notelrac@notelrac.com">notelrac@notelrac.com</a>
+    </address>
+  </body>
+</html>
+
+<!--
+     FILE ARCHIVED ON 07:56:03 Feb 02, 2022 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 22:45:02 Apr 26, 2023.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 95.596
+  exclusion.robots: 0.082
+  exclusion.robots.policy: 0.069
+  cdx.remote: 0.063
+  esindex: 0.009
+  LoadShardBlock: 66.307 (3)
+  PetaboxLoader3.datanode: 123.366 (5)
+  load_resource: 237.528 (2)
+  PetaboxLoader3.resolve: 90.289 (2)
+-->

--- a/grabbag/tutorials/index.html
+++ b/grabbag/tutorials/index.html
@@ -32,7 +32,7 @@
 
     <p>If you have written anything about sed - whether an introduction, how sed got you out of a
     real-life situation, or perhaps an advanced technique you've discovered - you may like have
-    your work published here. <a href="https://web.archive.org/web/20210916192526/mailto:bonzini@gnu.org">Your contribution</a> will be very
+    your work published here. <a href="mailto:bonzini@gnu.org">Your contribution</a> will be very
     welcome.</p>
 
     <h3 id="intros">Intros</h3>
@@ -54,11 +54,11 @@
         <div class="last">
           The official, indispensable sed FAQ. This file was recently updated. Also available
           as <a href="sedfaq.zip">ZIP-compressed HTML</a> (75kb).  The latest
-          version can always be found on <a href="https://web.archive.org/web/20210916192526/http://www.student.northpark.edu/pemente/sed/sedfaq.html">the author's site</a>.
+          version can always be found on <a href="http://www.student.northpark.edu/pemente/sed/sedfaq.html">the author's site</a>.
         </div>
       </dd>
 
-      <dt><a href="https://web.archive.org/web/20210916192526/http://www.dreamwvr.com/sed-info/sed-faq.html">Another sed
+      <dt><a href="http://www.dreamwvr.com/sed-info/sed-faq.html">Another sed
       FAQ</a></dt>
 
       <dd>
@@ -71,7 +71,7 @@
 
       <dd>
         <div class="last">
-          By <a href="https://web.archive.org/web/20210916192526/mailto:cgd@teleweb.pt">Carlos Jorge G.Duarte</a>. A comprehensive and
+          By <a href="mailto:cgd@teleweb.pt">Carlos Jorge G.Duarte</a>. A comprehensive and
           leisurely r&eacute;sum&eacute;. Contains many interesting examples, and a useful command
           summary.
         </div>

--- a/grabbag/tutorials/index.html
+++ b/grabbag/tutorials/index.html
@@ -1,15 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html lang="en">
-  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
-<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
-<script type="text/javascript">
-  __wm.init("https://web.archive.org/web");
-  __wm.wombat("http://sed.sourceforge.net/grabbag/tutorials/","20210916192526","https://web.archive.org/","web","/_static/",
-	      "1631820326");
-</script>
-<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
-<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
-<!-- End Wayback Rewrite JS Include -->
+  <head>
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>Seders's grab bag - Tutorials</title>
@@ -180,24 +171,3 @@
     </div>
   </body>
 </html>
-
-<!--
-     FILE ARCHIVED ON 19:25:26 Sep 16, 2021 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 22:36:57 Apr 26, 2023.
-     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
-
-     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
-     SECTION 108(a)(3)).
--->
-<!--
-playback timings (ms):
-  captures_list: 144.248
-  exclusion.robots: 0.074
-  exclusion.robots.policy: 0.066
-  cdx.remote: 0.053
-  esindex: 0.007
-  LoadShardBlock: 83.782 (3)
-  PetaboxLoader3.datanode: 100.147 (4)
-  load_resource: 73.645
-  PetaboxLoader3.resolve: 30.047
--->

--- a/grabbag/tutorials/index.html
+++ b/grabbag/tutorials/index.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+  <head><script type="text/javascript" src="/_static/js/bundle-playback.js?v=1WaXNDFE" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("http://sed.sourceforge.net/grabbag/tutorials/","20210916192526","https://web.archive.org/","web","/_static/",
+	      "1631820326");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=S1zqJCYt" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
+    <title>Seders's grab bag - Tutorials</title>
+    <style type="text/css">@import url(/web/20210916192526cs_/http://sed.sourceforge.net/grabbag/seders.css);</style>
+  </head>
+
+  <body>
+    <div class="titolo">
+      <div class="sezioni">
+      <h1><a href="/web/20210916192526/http://sed.sourceforge.net/grabbag/"><span>seder's</span> grab bag</a></h1>
+      <ul>
+        <li><a href="/web/20210916192526/http://sed.sourceforge.net/grabbag/scripts/">scripts</a></li>
+        <li><a href="/web/20210916192526/http://sed.sourceforge.net/grabbag/tutorials/">tutorials</a></li>
+        <li><a href="/web/20210916192526/http://sed.sourceforge.net/grabbag/seders/">seders</a></li>
+        <li><a href="/web/20210916192526/http://sed.sourceforge.net/grabbag/ssed/">ssed</a></li>
+        <li><a href="/web/20210916192526/http://sed.sourceforge.net/grabbag/links/">links</a></li>
+      </ul>
+      </div>
+    </div>
+
+    <ul class="menu">
+      <li><a href="#intros">Intros</a></li>
+      <li><a href="#advanced">Advanced</a></li>
+      <li><a href="#misc">Miscellaneous</a></li>
+    </ul>
+
+    <div class="testo">
+    <h2>Sed Tutorials</h2>
+
+    <p>If you have written anything about sed - whether an introduction, how sed got you out of a
+    real-life situation, or perhaps an advanced technique you've discovered - you may like have
+    your work published here. <a href="https://web.archive.org/web/20210916192526/mailto:bonzini@gnu.org">Your contribution</a> will be very
+    welcome.</p>
+
+    <h3 id="intros">Intros</h3>
+
+    <dl>
+      <dt><a href="sed1line.txt">sed one-liners</a> (18kb)</dt>
+
+      <dd>
+        <div class="last">
+          The essential, official compendium of useful sed one-liners. Organised into sections by
+          usage, such as file spacing, line numbering, selective line removal/deletion and
+          optimisation.
+        </div>
+      </dd>
+
+      <dt><a href="sedfaq.txt">The sed FAQ v15</a> (168kb)</dt>
+
+      <dd>
+        <div class="last">
+          The official, indispensable sed FAQ. This file was recently updated. Also available
+          as <a href="sedfaq.zip">ZIP-compressed HTML</a> (75kb).  The latest
+          version can always be found on <a href="https://web.archive.org/web/20210916192526/http://www.student.northpark.edu/pemente/sed/sedfaq.html">the author's site</a>.
+        </div>
+      </dd>
+
+      <dt><a href="https://web.archive.org/web/20210916192526/http://www.dreamwvr.com/sed-info/sed-faq.html">Another sed
+      FAQ</a></dt>
+
+      <dd>
+        <div class="last">
+          And here is another sed FAQ, by a different person.
+        </div>
+      </dd>
+
+      <dt><a href="do_it_with_sed.txt">Do it with sed</a> (51kb)</dt>
+
+      <dd>
+        <div class="last">
+          By <a href="https://web.archive.org/web/20210916192526/mailto:cgd@teleweb.pt">Carlos Jorge G.Duarte</a>. A comprehensive and
+          leisurely r&eacute;sum&eacute;. Contains many interesting examples, and a useful command
+          summary.
+        </div>
+      </dd>
+
+      <dt><a href="sed_mcmahon.txt">SED - A Non-interactive Text Editor</a>
+      (32kb)</dt>
+
+      <dd>
+        <div class="last">
+          By Lee E. McMahon (1978). The definitive introduction, this well-known document used to
+          be distributed with UNIX systems. It examines each of sed's functions in depth and
+          includes useful examples.
+        </div>
+      </dd>
+
+      <dt><a href="sed_state.txt">Program state in sed</a> (4kb)</dt>
+
+      <dd>
+        <div class="last">
+          By Greg Ubben. A nice introduction to advanced sed, showing how to mantain state across
+          lines.
+        </div>
+      </dd>
+
+      <dt><a href="sed_introduction.txt">Introduction to Unix's SED editor</a></dt>
+
+      <dd>By F. Curtis Michel, Rice University, Houston.</dd>
+    </dl>
+
+    <h3 id="advanced">Advanced topics</h3>
+
+    <dl>
+      <dt><a href="indexer.txt">Using sed to create a book index</a> (12kb)</dt>
+
+      <dd>
+        <div class="last">
+          Eric Pement of <cite>Cornerstone</cite> magazine shows how he used sed and other
+          utilities to massage an unsorted list of book references into an index.
+        </div>
+      </dd>
+
+      <dt><a href="lookup_tables.txt">Using lookup tables with s///</a> (9kb)</dt>
+
+      <dd>
+        <div class="last">
+          Part 1 of Greg Ubben's analysis of a complex sed script he wrote to sort, delimit and
+          number an input file containing tabulated data. Lookup tables are a powerful technique
+          for the serious seder's armoury.
+        </div>
+      </dd>
+
+      <dt><a href="lookup_table_counter.txt">A lookup-table counter</a> (11kb)</dt>
+
+      <dd>
+        <div class="last">
+          Part 2 of Greg's script analysis looks at how he implemented a counter using lookup
+          tables. This complex problem is described step by step from the basics, following through
+          Greg's reasoning until we finally reach the solution.
+        </div>
+      </dd>
+
+      <dt><a href="greg_wc.txt">Counting words</a> (3kb)<br>
+       <a href="greg_add.txt">Adding a list of decimals</a> (3kb)</dt>
+
+      <dd>Greg explains how to count words and how to add a list of decimal numbers using a simple
+      analog format.</dd>
+    </dl>
+
+    <h3 id="misc">Miscellaneous</h3>
+
+    <dl>
+      <dt><a href="nasty_characters.txt">When seemingly obvious scripts fail</a> (2kb)</dt>
+      <dd>
+        <div class="last">
+          <tt>sed</tt> FAQ author Eric Pement explains why sometimes you cannot get your
+          one-liner right.
+        </div>
+      </dd>
+
+      <dt><a href="hanoi.htm">Towers of Hanoi with <tt>sed</tt></a> (18kb)</dt>
+
+      <dd>
+        <div class="last">
+          A document which shows how to make <tt>sed</tt> solve the classic Towers of Hanoi
+          game.
+        </div>
+      </dd>
+
+      <dt><a href="custom_sed.htm">Proposals for a custom sed</a> (18kb)</dt>
+
+      <dd>A list of proposals to make sed more versatile without sacrificing its speed and overall
+      philosophy. I implemented a few of these in <a href="/web/20210916192526/http://sed.sourceforge.net/grabbag/ssed/"><tt>super-sed</tt></a> and in GNU sed 4.0.</dd>
+    </dl>
+
+    <p><span class="update">Updated 7 Oct 2006</span></p>
+    </div>
+  </body>
+</html>
+
+<!--
+     FILE ARCHIVED ON 19:25:26 Sep 16, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 22:36:57 Apr 26, 2023.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 144.248
+  exclusion.robots: 0.074
+  exclusion.robots.policy: 0.066
+  cdx.remote: 0.053
+  esindex: 0.007
+  LoadShardBlock: 83.782 (3)
+  PetaboxLoader3.datanode: 100.147 (4)
+  load_resource: 73.645
+  PetaboxLoader3.resolve: 30.047
+-->

--- a/grabbag/tutorials/index.html
+++ b/grabbag/tutorials/index.html
@@ -4,19 +4,19 @@
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> 
     <title>Seders's grab bag - Tutorials</title>
-    <style type="text/css">@import url(/web/20210916192526cs_/http://sed.sourceforge.net/grabbag/seders.css);</style>
+    <style type="text/css">@import url(/grabbag/seders.css);</style>
   </head>
 
   <body>
     <div class="titolo">
       <div class="sezioni">
-      <h1><a href="/web/20210916192526/http://sed.sourceforge.net/grabbag/"><span>seder's</span> grab bag</a></h1>
+      <h1><a href="/grabbag/"><span>seder's</span> grab bag</a></h1>
       <ul>
-        <li><a href="/web/20210916192526/http://sed.sourceforge.net/grabbag/scripts/">scripts</a></li>
-        <li><a href="/web/20210916192526/http://sed.sourceforge.net/grabbag/tutorials/">tutorials</a></li>
-        <li><a href="/web/20210916192526/http://sed.sourceforge.net/grabbag/seders/">seders</a></li>
-        <li><a href="/web/20210916192526/http://sed.sourceforge.net/grabbag/ssed/">ssed</a></li>
-        <li><a href="/web/20210916192526/http://sed.sourceforge.net/grabbag/links/">links</a></li>
+        <li><a href="/grabbag/scripts/">scripts</a></li>
+        <li><a href="/grabbag/tutorials/">tutorials</a></li>
+        <li><a href="/grabbag/seders/">seders</a></li>
+        <li><a href="/grabbag/ssed/">ssed</a></li>
+        <li><a href="/grabbag/links/">links</a></li>
       </ul>
       </div>
     </div>
@@ -164,7 +164,7 @@
       <dt><a href="custom_sed.htm">Proposals for a custom sed</a> (18kb)</dt>
 
       <dd>A list of proposals to make sed more versatile without sacrificing its speed and overall
-      philosophy. I implemented a few of these in <a href="/web/20210916192526/http://sed.sourceforge.net/grabbag/ssed/"><tt>super-sed</tt></a> and in GNU sed 4.0.</dd>
+      philosophy. I implemented a few of these in <a href="/grabbag/ssed/"><tt>super-sed</tt></a> and in GNU sed 4.0.</dd>
     </dl>
 
     <p><span class="update">Updated 7 Oct 2006</span></p>


### PR DESCRIPTION
The original contents from the http://sed.sf.net/grabbag website were
lost (see issue https://github.com/aureliojargas/sed.sf.net/issues/11).

Here are all the HTML files I could restore, downloaded directly from
the Internet Archive by using the following command:

```
wget --recursive --no-clobber --page-requisites \
     --domains web.archive.org --no-parent
```

to download the following URLs:

* https://web.archive.org/web/20211028141011/http://sed.sourceforge.net/grabbag/
* https://web.archive.org/web/20210916192909/http://sed.sourceforge.net/grabbag/scripts/
* https://web.archive.org/web/20210916192526/http://sed.sourceforge.net/grabbag/tutorials/
* https://web.archive.org/web/20220823200955/http://sed.sourceforge.net/grabbag/seders/
* https://web.archive.org/web/20220728160200/http://sed.sourceforge.net/grabbag/ssed/
* https://web.archive.org/web/20210916192447/http://sed.sourceforge.net/grabbag/links/

Note that after the download, some cleanup was needed on the files:

- Remove Internet-Archive-inserted code (tags and comments).

- Fix all the website links. They were all changed to point to Internet Archive snapshots and I've used some sed commands to undo that.

Please check the individual commits in this PR for the details on those changes and the commands used.
